### PR TITLE
Doc for vistrails autowrapping

### DIFF
--- a/doc/resource/dev_guide/doc_doc.rst
+++ b/doc/resource/dev_guide/doc_doc.rst
@@ -16,6 +16,19 @@ The docstrings must follow the `numpydoc
 <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_
 format.
 
+For the 'Returns' section of numpydoc, you must include the return
+variable name because this variable name is needed for automated vistrails
+wrapping (the return variable names are the output ports).  Example: ::
+
+
+   Returns
+   -------
+   avg : float
+       The average
+   stdev : float
+       The standard deviation
+
+
 Sphinx
 ------
 


### PR DESCRIPTION
@NSLS-II/development-team NEW DOCUMENTATION REQUIREMENT!!
- For vistrails autowrapping, we need to know the name of the
  return variables because those become the names of the output
  ports.
