### PR TITLE
Rewrite of documentation for recip.process_to_q

### DIFF
--- a/nsls2/recip.py
+++ b/nsls2/recip.py
@@ -277,7 +277,7 @@ def process_to_q(setting_angles, detector_size, pixel_size,
 
     # ending time for the process
     t2 = time.time()
-    logger.info("--- Processing time for {0} {1} x {2} images took {3} seconds."
+    logger.info("Processing time for {0} {1} x {2} images took {3} seconds."
                 "".format(setting_angles.shape[0], detector_size[0],
                           detector_size[1], (t2-t1)))
     return hkl[:, :3]

--- a/nsls2/tests/test_recip.py
+++ b/nsls2/tests/test_recip.py
@@ -4,21 +4,13 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import numpy as np
-from numpy.testing import (assert_array_equal, assert_array_almost_equal,
-                           assert_almost_equal)
 
-from nose.tools import assert_equal, assert_true, raises
-
-import nsls2.core as core
+from nose.tools import raises
 
 from nsls2.testing.decorators import known_fail_if
 import numpy.testing as npt
 from nsls2 import recip
 
-
-@raises(ValueError, KeyError)
-def _process_to_q_exception(param_dict, frame_mode):
-    hkl = recip.process_to_q(frame_mode=frame_mode, **param_dict)
 
 @known_fail_if(six.PY3)
 def test_process_to_q():
@@ -48,16 +40,12 @@ def test_process_to_q():
     pdict['wavelength'] = wavelength
     pdict['ub'] = ub_mat
     # ensure invalid entries for frame_mode actually fail
-    for fails in [0, 5, 'cat']:
-        yield _process_to_q_exception, pdict, fails
-    frame_mode_passes = recip.process_to_q.frame_mode
-    for _ in range(len(frame_mode_passes)):
-        frame_mode_passes.append(_+1)
+
     # smoketest the frame_mode variable
-    for passes in frame_mode_passes:
+    for passes in recip.process_to_q.frame_mode:
         recip.process_to_q(frame_mode=passes, **pdict)
 
-    #todo test frame_modes 1, 2, and 3
+    # todo test frame_modes 1, 2, and 3
     # test that the values are coming back as expected for frame_mode=4
     hkl = recip.process_to_q(**pdict)
 
@@ -68,3 +56,39 @@ def test_process_to_q():
 
     for pixel, kn_hkl in known_hkl:
         npt.assert_array_almost_equal(hkl[pixel], kn_hkl, decimal=8)
+
+
+@raises(KeyError)
+def _process_to_q_exception(param_dict, frame_mode):
+    recip.process_to_q(frame_mode=frame_mode, **param_dict)
+
+
+def test_frame_mode_fail():
+    detector_size = (256, 256)
+    pixel_size = (0.0135*8, 0.0135*8)
+    calibrated_center = (256/2.0, 256/2.0)
+    dist_sample = 355.0
+
+    energy = 640  # (  in eV)
+    # HC_OVER_E to convert from Energy to wavelength (Lambda)
+    hc_over_e = 12398.4
+    wavelength = hc_over_e / energy  # (Angstrom )
+
+    ub_mat = np.array([[-0.01231028454, 0.7405370482, 0.06323870032],
+                       [0.4450897473, 0.04166852402, -0.9509449389],
+                       [-0.7449130975, 0.01265920962, -0.5692399963]])
+
+    setting_angles = np.array([[40., 15., 30., 25., 10., 5.],
+                              [90., 60., 0., 30., 10., 5.]])
+    # delta=40, theta=15, chi = 90, phi = 30, mu = 10.0, gamma=5.0
+    pdict = {}
+    pdict['setting_angles'] = setting_angles
+    pdict['detector_size'] = detector_size
+    pdict['pixel_size'] = pixel_size
+    pdict['calibrated_center'] = calibrated_center
+    pdict['dist_sample'] = dist_sample
+    pdict['wavelength'] = wavelength
+    pdict['ub'] = ub_mat
+
+    for fails in [0, 5, 'cat']:
+        yield _process_to_q_exception, pdict, fails


### PR DESCRIPTION
- Exposed the frame_mode variable as an input parameter to
  recip.process_to_q
- Added new tests to make sure that bad entries for frame_mode
  actually fail and that good entries do not raise an exception
