### PR TITLE
API : removed function that was too clever

### DIFF
--- a/doc/resource/api/core.rst
+++ b/doc/resource/api/core.rst
@@ -47,7 +47,6 @@ Binning
    :toctree: generated/
 
    bin_1D
-   bin_image_to_1D
    wedge_integration
    grid3d
 

--- a/nsls2/core.py
+++ b/nsls2/core.py
@@ -595,72 +595,6 @@ def bin_1D(x, y, nx=None, min_x=None, max_x=None):
     return bins, val, count
 
 
-def bin_image_to_1D(img,
-                    calibrated_center,
-                    pixel_to_1D_func, pixel_to_1D_kwarg=None,
-                    bin_min=None, bin_max=None, bin_num=None):
-    """Integrates an image to a 1D curve.
-
-    The first step is use the `pixel_to_1D_func` to convert
-    each pixel location to a scalar.  Example of this would be
-    distance from the center in mm, azimuthal angle, or converting to q.
-
-    Parameters
-    ----------
-    img : ndarray
-        The image to integrate
-
-    calibrated_center : tuple
-        The center of the image (row, col)
-
-    pixel_to_1D_func : function
-        A function that takes in an image shape, calibrated_center
-        and a dict of kwargs and returns an array of the same shape
-        filled with a scalar for that pixel position (R2 -> R1 mapping).
-        The function must have the following signature ::
-
-            output = func(img.shape, calibrated_center, **pixel_to_1D_kwarg)
-
-        such that ::
-
-            output.shape == img.shape
-
-        and output[i, j] corresponds to img[i, j]
-
-
-    pixel_to_1D_kwargs : dict, optional
-        Any additional keyword arguments to pass through to the warp function
-
-    bin_min : float, optional
-        The lower limit of the binning
-
-    bin_max : float, optional
-        The upper limit of binning
-
-    bin_num : int, optional
-        The number of bins
-
-    Returns
-    -------
-    bin_edges : array
-        The bin edges, length N+1
-
-    bin_sum : array
-        The sum of the pixels that fell in each bin
-
-    bin_count : array
-        The number of pixels in each bin
-    """
-    if pixel_to_1D_kwarg is None:
-        pixel_to_1D_kwarg = {}
-
-    values_1D = pixel_to_1D_func(img.shape, calibrated_center,
-                             **pixel_to_1D_kwarg)
-
-    return bin_1D(values_1D.ravel(), img.ravel(), min_x=bin_min,
-                  max_x=bin_max, nx=bin_num)
-
-
 def pixel_to_radius(shape, calibrated_center, pixel_size=None):
     """
     Converts pixel positions to radius from the calibrated center
@@ -734,7 +668,7 @@ def radius_to_twotheta(dist_sample, radius):
     """
     Converts radius from the calibrated center to scattering angle
     (2:math:`2\\theta`) with known detector to sample distance.
-    
+
     Parameters
     ----------
     dist_sample : float

--- a/nsls2/tests/test_core.py
+++ b/nsls2/tests/test_core.py
@@ -318,56 +318,6 @@ def test_large_verbosedict():
         assert(False)
 
 
-def test_bin_image_to_1D_radius():
-    shape = (256, 300)
-    center = (120, 150)
-    R = core.pixel_to_radius(shape, center)
-
-    I = np.zeros_like(R, dtype='int')
-
-    ring_width = 2
-
-    ring_locs = [10, 50, 76]
-    for r in ring_locs:
-        I += ((R >= r) * (R < (r + ring_width))) * r
-
-    A, B, C = core.bin_image_to_1D(I, center,
-                    core.pixel_to_radius,
-                    bin_min=0, bin_max=100,
-                    bin_num=50)
-
-    for j, (a, b, c) in enumerate(zip(A, B, C)):
-        if j*2 in ring_locs:
-            assert b == j * 2 * c
-        else:
-            assert b == 0
-
-
-def test_bin_image_to_1D_phi():
-    shape = (256, 300)
-    center = (120, 150)
-    phi = core.pixel_to_phi(shape, center)
-
-    nphi_steps = 25
-
-    I = np.zeros_like(phi, dtype='int')
-
-    phi_steps = np.linspace(-np.pi, np.pi + np.spacing(np.pi),
-                            nphi_steps + 1,
-                            endpoint=True)
-    for j, (bot, top) in enumerate(core.pairwise(phi_steps)):
-        mask = (phi >= bot) * (phi < top)
-        I[mask] = j + 1
-
-    A, B, C = core.bin_image_to_1D(I, center,
-                    core.pixel_to_phi,
-                    bin_min=-np.pi, bin_max=np.pi,
-                    bin_num=nphi_steps)
-
-    for j, (a, b, c) in enumerate(zip(A, B, C)):
-        assert b == c * (j + 1)
-
-
 def test_d_q_conversion():
     assert_equal(2 * np.pi, core.d_to_q(1))
     assert_equal(2 * np.pi, core.q_to_d(1))


### PR DESCRIPTION
bin_image_to_1D was far to clever for the benefit it provided.

It alleviated the need to make one call at the cost of adding
a function with took a function as an argument and needed
to be able to blind-pass dictionary of kwargs through.  This
is a nightmare for wrapping at vistrails and difficult to
document or debug for API-usage.
