### PR TITLE
MNT: Invoke coverage with the 'coverage run`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-source=scikit-beam
+source=skbeam
 [report]
 omit =
     */python?.?/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - pip install codecov
 
 script:
-  - python run_tests.py
+  - coverage run run_tests.py
   - if [ $TRAVIS_PYTHON_VERSION == 3.5 ]; then
       conda install sphinx numpydoc ipython jupyter pip matplotlib;
       pip install sphinx_bootstrap_theme;

--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@ pip install nose coverage setuptools
 ```
 python run_tests.py
 ```
+
+**and you can check the code coverage with**
+```
+coverage run run_tests.py
+coverage report -m
+```

--- a/run_tests.py
+++ b/run_tests.py
@@ -15,9 +15,10 @@ import nose
 from skbeam.testing.noseclasses import KnownFailure
 
 plugins = [KnownFailure]
-env = {"NOSE_WITH_COVERAGE": 1,
-       'NOSE_COVER_PACKAGE': 'skbeam',
-       'NOSE_COVER_HTML': 1}
+# env = {"NOSE_WITH_COVERAGE": 1,
+#        'NOSE_COVER_PACKAGE': 'skbeam',
+#        'NOSE_COVER_HTML': 1}
+env = {}
 # Nose doesn't automatically instantiate all of the plugins in the
 # child processes, so we have to provide the multiprocess plugin with
 # a list.


### PR DESCRIPTION
Just listened to a podcast today with the author of the `coverage` package 
who recommends that you invoke coverage via `coverage run <test_script.py`.
This is also what is listed on the home page of the [coverage docs] 
(https://coverage.readthedocs.org/en/coverage-4.0.3/).  The podcast can 
be found [here] (https://coverage.readthedocs.org/en/coverage-4.0.3/)
 for those of you that are interested.