### PR TITLE
CI: Build docs separately from automated testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,8 @@ script:
   - flake8 $TRAVIS_BUILD_DIR/skbeam
 
 after_success:
-  - coveralls
-  - codecov
+  - if [ $RUN_TESTS == 'true' ]; then coveralls; fi;
+  - if [ $RUN_TESTS == 'true' ]; then codecov; fi;
   - if [ $TRAVIS_BRANCH == 'master' ] && [ $TRAVIS_PULL_REQUEST == 'false' ] && [ $BUILD_DOCS ]; then
       cd doc;
       chmod +x push_docs.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ addons:
       - pandoc
 env:
   global:
+    - RUN_TESTS: true
     - GH_REF: github.com/scikit-beam/scikit-beam.git
     - secure: "KzntGlmLDUZlAB8ZiSRBtONJypv4atrnFxl+THCW8kg6YbiODcCxG9cez7mfmh63wpJ54+zeGvgGljeVvjb7bjB2p+4hZy+mLoP9xoE1w5qF4XaQ5YTOYaSQqCeWa5cEIi+854gFX7gOfW5qL+EJf7h3HtmndI15zaU5gOPjSDU="
-
+matrix:
+  include:
+    - python: 3.5
+      env: BUILD_DOCS=true RUN_TESTS=false
 python:
   - 2.7
   - 3.4
@@ -35,8 +39,9 @@ install:
   - pip install codecov
 
 script:
-  - coverage run run_tests.py
-  - if [ $TRAVIS_PYTHON_VERSION == 3.5 ]; then
+  - if [ $RUN_TESTS == 'true' ]; then coverage run run_tests.py; fi;
+  - if [ $RUN_TESTS == 'true' ]; then flake8 $TRAVIS_BUILD_DIR/skbeam; fi;
+  - if [ $BUILD_DOCS == 'true' ]; then
       conda install sphinx numpydoc ipython jupyter pip matplotlib;
       pip install sphinx_bootstrap_theme sphinxcontrib-napoleon;
       cd ..;
@@ -50,7 +55,7 @@ script:
 after_success:
   - coveralls
   - codecov
-  - if [ $TRAVIS_BRANCH == 'master' ] && [ $TRAVIS_PULL_REQUEST == 'false' ]; then
+  - if [ $TRAVIS_BRANCH == 'master' ] && [ $TRAVIS_PULL_REQUEST == 'false' ] && [ $BUILD_DOCS ]; then
       cd doc;
       chmod +x push_docs.sh;
       ./push_docs.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
 env:
   global:
     - RUN_TESTS: true
+    - BUILD_DOCS: false
     - GH_REF: github.com/scikit-beam/scikit-beam.git
     - secure: "KzntGlmLDUZlAB8ZiSRBtONJypv4atrnFxl+THCW8kg6YbiODcCxG9cez7mfmh63wpJ54+zeGvgGljeVvjb7bjB2p+4hZy+mLoP9xoE1w5qF4XaQ5YTOYaSQqCeWa5cEIi+854gFX7gOfW5qL+EJf7h3HtmndI15zaU5gOPjSDU="
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ script:
       chmod +x build_docs.sh;
       ./build_docs.sh;
     fi;
-  - flake8 $TRAVIS_BUILD_DIR/skbeam
 
 after_success:
   - if [ $RUN_TESTS == 'true' ]; then coveralls; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ install:
   # # code.  We could also setup.py develop, but I'm not sure if that is any
   # # better
   - python setup.py install build_ext -i
-  - pip install coveralls
   - pip install codecov
 
 script:
@@ -52,7 +51,6 @@ script:
     fi;
 
 after_success:
-  - if [ $RUN_TESTS == 'true' ]; then coveralls; fi;
   - if [ $RUN_TESTS == 'true' ]; then codecov; fi;
   - if [ $TRAVIS_BRANCH == 'master' ] && [ $TRAVIS_PULL_REQUEST == 'false' ] && [ $BUILD_DOCS ]; then
       cd doc;

--- a/doc/example/Makefile
+++ b/doc/example/Makefile
@@ -1,4 +1,4 @@
 notebooks:
 	python get_examples_repo.py
 	python write_main_index.py
-	ipython nbconvert --config convert_config.py --to rst
+	jupyter nbconvert --config convert_config.py --to rst


### PR DESCRIPTION
This is something that was requested by @tacaswell because the sphinx
logs spit out a tremendous amount of information that makes it difficult
to examine the logs for test failures.