### PR TITLE
Add mask to circular average

### DIFF
--- a/skbeam/core/roi.py
+++ b/skbeam/core/roi.py
@@ -399,7 +399,7 @@ def mean_intensity(images, labeled_array, index=None):
 
 
 def circular_average(image, calibrated_center, threshold=0, nx=100,
-                     pixel_size=(1, 1),  min_x=None, max_x=None):
+                     pixel_size=(1, 1),  min_x=None, max_x=None, mask=None):
     """Circular average of the the image data
     The circular average is also known as the radial integration
     Parameters
@@ -410,7 +410,7 @@ def circular_average(image, calibrated_center, threshold=0, nx=100,
         The center of the image in pixel units
         argument order should be (row, col)
     threshold : int, optional
-        Ignore counts above `threshold`
+        Ignore counts below `threshold`
         default is zero
     nx : int, optional
         number of bins in x
@@ -423,14 +423,29 @@ def circular_average(image, calibrated_center, threshold=0, nx=100,
         Left edge of first bin defaults to minimum value of x
     max_x : float, optional number of pixels
         Right edge of last bin defaults to maximum value of x
+    mask : mask for 2D data. Assumes 1 is non masked and 0 masked.
+        None defaults to no mask.
+    
     Returns
     -------
     bin_centers : array
         The center of each bin in R. shape is (nx, )
     ring_averages : array
         Radial average of the image. shape is (nx, ).
+
+    See Also
+    --------
+    bad_to_nan_gen : Create a mask with np.nan entries
+
+    Notes
+    -----
     """
     radial_val = utils.radial_grid(calibrated_center, image.shape, pixel_size)
+
+    if mask is not None:
+        w = np.where(mask == 1)
+        radial_val = radial_val[w]
+        image = image[w]
 
     bin_edges, sums, counts = utils.bin_1D(np.ravel(radial_val),
                                            np.ravel(image), nx,

--- a/skbeam/core/tests/test_roi.py
+++ b/skbeam/core/tests/test_roi.py
@@ -318,6 +318,16 @@ def test_circular_average():
                                                max_x=10, nx=None)
     assert_array_almost_equal(bin_cen1, [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5,
                                          7.5, 8.5])
+    mask = np.ones_like(image)
+    mask[4:6,2:3] = 0
+
+    bin_cen_masked, ring_avg_masked = roi.circular_average(image, calib_center, 
+                                                    min_x=0, max_x=10,nx=6,mask=mask)
+    assert_array_almost_equal(bin_cen_masked, [ 0.83333333,  2.5, 4.16666667,
+        5.83333333,  7.5, 9.16666667])
+            
+    assert_array_almost_equal(ring_avg_masked, [ 8.88888889,  3.84615385,  2.5
+        ,0.,  0.,  0.])
 
 
 def test_kymograph():


### PR DESCRIPTION
This may be redundant but I don't think circular_average supports masks? Is this true, and if so, is it possible to add this feature? I am trying to migrate to skbeam :-)

I know @yugangzhang already has code to do this and I'm sure there are numerous others. If such code exists, please point me to it and ignore this. :)

@danielballan also you might know more about this.

Test of the PR here (and a nosetest included in PR)

``` python
from matplotlib.pyplot import figure, loglog,plot, clf
import numpy as np
from skbeam.core.roi import circular_average

#try something simpler
Nx, Ny = 100, 100
x0,y0 = 50,50
nor = 100
x = np.arange(Nx)-x0
y = np.arange(Ny)-y0
X,Y = np.meshgrid(x,y)
R = np.sqrt(X**2 + Y**2)
IMG = R**2
mask = np.ones_like(IMG)
IMG2 = np.copy(IMG)
IMG2[10:20,10:20] = 1e5
mask[10:20,10:20] = 0#mask some region
r,I = circular_average(IMG,(y0,x0), nx=nor)
rmasked,Imasked = circular_average(IMG2,(y0,x0), nx=nor, mask=mask)
rbad,Ibad = circular_average(IMG2,(y0,x0), nx=nor)


figure(2);clf();
loglog(r,I,color='k')
loglog(rmasked,Imasked,color='r')

#plot percentage error just to see how masking affects circavg
figure(3);clf();
plot(np.abs(I-Imasked)/I)
```