### PR TITLE
Image filling using Gaussian smoothing

### DIFF
--- a/skbeam/core/image.py
+++ b/skbeam/core/image.py
@@ -44,7 +44,7 @@ import logging
 from scipy.ndimage.filters import gaussian_filter
 logger = logging.getLogger(__name__)
 
-from core.stats import poissonize
+from skbeam.core.stats import poissonize
 
 
 def find_ring_center_acorr_1D(input_image):

--- a/skbeam/core/image.py
+++ b/skbeam/core/image.py
@@ -44,6 +44,8 @@ import logging
 from scipy.ndimage.filters import gaussian_filter
 logger = logging.getLogger(__name__)
 
+from core.stats import poissonize
+
 
 def find_ring_center_acorr_1D(input_image):
     """
@@ -214,10 +216,8 @@ def gaussfill(img, mask, sigma=30, poisson=False, Navg=None):
     imgmskrat = gaussian_filter(mask*0.+1, sigma)
     w = np.where((mask < .1)*(imgmsk > 0))
     imgf[w] = imgg[w]/imgmsk[w]*imgmskrat[w]
+
     if poisson:
-        if Navg is None:
-            Navg = 1.
-        # some threshold since poisson doesnt work at high vals
-        imgf[w] = np.random.poisson(imgf[w]*(imgf[w] < 1e9)*Navg)/Navg
+        imgf[w] = poissonize(imgf[w], Navg=Navg)
 
     return imgf

--- a/skbeam/core/stats.py
+++ b/skbeam/core/stats.py
@@ -103,7 +103,7 @@ def poissonize(data, Navg=None):
 
         Notes
         -----
-            If larger than some threshold, the Poisson 
+            If larger than some threshold, the Poisson
 
     '''
     if Navg is None:

--- a/skbeam/core/stats.py
+++ b/skbeam/core/stats.py
@@ -88,3 +88,31 @@ def statistics_1D(x, y, stat='mean', nx=None, min_x=None, max_x=None):
     val, _, _ = scipy.stats.binned_statistic(x, y, statistic=stat, bins=bins)
     # return the two arrays
     return bins, val
+
+
+def poissonize(data, Navg=None):
+    ''' This function will sample the points from image from a poisson
+            distribution.
+
+        Parameters
+        ----------
+        img : the data in question
+
+        Navg : Specify the number of images this is an average of
+            Poisson will be sampled from (data*Navg)
+
+        Notes
+        -----
+            If larger than some threshold, the Poisson 
+
+    '''
+    if Navg is None:
+        Navg = 1.
+    # some threshold since poisson doesnt work at high vals
+    _poiss_thresh = 1e18
+    data = np.random.poisson(data*(data < _poiss_thresh)*Navg)/Navg
+    w = np.where(data > _poiss_thresh)
+    if len(w[0]) > 0:
+        data[w] = np.nan
+
+    return data

--- a/skbeam/core/tests/test_image.py
+++ b/skbeam/core/tests/test_image.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 from skbeam.core import roi
 import numpy.random
+from numpy.testing import assert_array_almost_equal
 import skimage.draw as skd
 from scipy.ndimage.morphology import binary_dilation
 import skbeam.core.image as nimage
 
-from numpy.testing import assert_array_almost_equal
 
 from nose.tools import assert_equal, assert_raises
 
@@ -79,6 +79,18 @@ def test_construct_circ_avg_image():
     with assert_raises(ValueError):
         nimage.construct_circ_avg_image(bin_cen, ring_avg, center=calib_center,
                                         pixel_size=(2, 1))
+
+
+def test_gaussfill():
+    img = np.arange(100, dtype=float).reshape((10, 10))
+    mask = np.ones_like(img)
+    mask[4] = 0
+    img_s = nimage.gaussfill(img, mask, sigma=3)
+
+    assert_array_almost_equal(img_s[4], [43.07573008, 43.33184697, 43.81476674,
+                              44.47224713, 45.23831993, 46.04106681,
+                              46.80713961, 47.46462001, 47.94753977,
+                              48.20365666])
 
 
 if __name__ == '__main__':

--- a/skbeam/core/tests/test_image.py
+++ b/skbeam/core/tests/test_image.py
@@ -91,6 +91,10 @@ def test_gaussfill():
                               44.47224713, 45.23831993, 46.04106681,
                               46.80713961, 47.46462001, 47.94753977,
                               48.20365666])
+    np.random.seed(13423)
+    img_s = nimage.gaussfill(img, mask, sigma=3, poisson=True, Navg=2)
+    assert_array_almost_equal(img_s[4], [45.5, 44., 39., 39., 44.5,
+                              47.5, 43., 34.5, 45., 53.])
 
 
 if __name__ == '__main__':

--- a/skbeam/core/tests/test_image.py
+++ b/skbeam/core/tests/test_image.py
@@ -8,6 +8,7 @@ from scipy.ndimage.morphology import binary_dilation
 import skbeam.core.image as nimage
 
 
+from numpy.testing import assert_array_almost_equal
 from nose.tools import assert_equal, assert_raises
 
 

--- a/skbeam/core/tests/test_stats.py
+++ b/skbeam/core/tests/test_stats.py
@@ -1,6 +1,6 @@
-from skbeam.core.stats import statistics_1D
+from skbeam.core.stats import statistics_1D, poissonize
 import numpy as np
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_almost_equal
 
 
 def test_statistics_1D():
@@ -15,3 +15,24 @@ def test_statistics_1D():
                               np.linspace(0, 1, nx + 1, endpoint=True))
     assert_array_almost_equal(val,
                               np.sum(y.reshape(nx, -1), axis=1)/10.)
+
+
+def test_poissonize():
+    # choose some seed
+    seed = 41301823
+    np.random.seed(seed)
+    mu = 1000
+    x = np.ones(10)*mu
+    v1 = poissonize(x)
+    v2 = poissonize(x, Navg=10)
+
+    v1avg = np.average(v1)
+    v2avg = np.average(v2)
+    assert_almost_equal(v1avg, 988.0)
+    assert_almost_equal(v2avg, 1006.4)
+    assert_array_almost_equal(v1, np.array([908., 1019., 1006., 1002., 973.,
+                                            987., 950., 988., 1027., 1020.]))
+
+    assert_array_almost_equal(v2, np.array([1014.4, 994.3, 1015.5, 1015.4,
+                                            995.7, 988.5, 1002., 1020.3,
+                                            1011.4, 1006.5]))


### PR DESCRIPTION
(Mentions: @danielballan @tacaswell)
This is more an aesthetic feature. Fill an image using Gaussian smoothing (see notebook reference below for quick transfer of information through an image).

Will later add savitzky golay and circular average filling (basically, reinterpolating circular average and sampling from Poisson distribution to make it blend in) a little later. I figure it might be best to add in things step by step. (If this is something useful)

This does two main things:
1. Fills in the image by 'bleeding' in values from neighboring pixels using Gaussian smoothing.
2. Uses (if desired) the intensity values that 'bled' in as a sample to the Poisson distribution. This makes the 'bled' in pixels blend better with the image. Allows for Poisson distribution and quasi-Poisson where the images are actually the average of a sequence of images averaged (of which the statistics came from a Poisson distribution).

Future thoughts: could possibly include multinomial distribution for undersampled speckle (when the pixels obey speckle statistics but they are smaller than a pixel).

Examples (see my notebook):
https://github.com/ordirules/notebooks/blob/master/gaussianfill-example.ipynb
(note the smaller gaps fill well whereas the larger ones do not, for obvious reasons. Both cases are meant to sort of display the limits of this)

Future method plans: circular average filling, Savitzky-Golay filling.

Will also add a test to this later.