### PR TITLE
Generalize binning

### DIFF
--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -397,9 +397,15 @@ class BinnedStatistic2D(BinnedStatisticDD):
         return super(BinnedStatistic2D, self).__call__(values)
 
 
-def get_r_phi(rowsize, colsize, rowc, colc):
-    rowc = rowsize//2 if rowc is None else rowc
-    colc = colsize//2 if colc is None else colc
+def get_r_phi(shape, origin):
+    rowsize = shape[0]
+    colsize = shape[1]
+    if origin is None:
+        rowc = rowsize//2
+        colc = colsize//2
+    else:
+        rowc = origin[0]
+        colc = origin[1]
     row = np.arange(rowsize)-rowc
     col = np.arange(colsize)-colc
     # meshgrid indexing='ij' option requires numpy 1.7 or later
@@ -415,13 +421,13 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
     image in both radius and phi.
     """
 
-    def __init__(self, rowsize, colsize, bins=10, range=None,
-                 rowc=None, colc=None, mask=None, statistic='mean'):
+    def __init__(self, shape, bins=10, range=None,
+                 origin=None, mask=None, statistic='mean'):
         """
         Parameters:
         -----------
-        rowsize,colsize: int
-            shape of image in pixels.
+        shape: tuple of ints of length 2.
+            shape of image.
         bins : int or [int, int] or array_like or [array, array], optional
             The bin specification:
             * number of bins for the two dimensions (nr=nphi=bins),
@@ -437,9 +443,9 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
             [[rmin, rmax], [phimin, phimax]]. All values outside of this range
             will be considered outliers and not tallied in the histogram.
             See "bins" parameter for definition of phi.
-        rowc,colc: int, optional
+        origin: tuple of ints with length 2, optional
             location (in pixels) of origin (default: image center).
-        mask: 2-dimensional np.ndarray, optional
+        mask: 2-dimensional np.ndarray of ints, optional
             array of zero/non-zero values, same shape as image used
             in __call__.  zero values will be ignored.
         statistic : string or callable, optional
@@ -460,7 +466,7 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
                 will be called on the values in each bin.  Empty bins will be
                 represented by function([]), or NaN if this returns an error.
         """
-        rpix, phipix = get_r_phi(rowsize, colsize, rowc, colc)
+        rpix, phipix = get_r_phi(rowsize, colsize, origin)
 
         self.expected_shape = rpix.shape
         if mask is not None:
@@ -491,13 +497,13 @@ class RadialBinnedStatistic(BinnedStatistic1D):
     image in both radius and phi.
     """
 
-    def __init__(self, rowsize, colsize, bins=10, range=None,
-                 rowc=None, colc=None, mask=None, statistic='mean'):
+    def __init__(self, shape, bins=10, range=None,
+                 origin=None, mask=None, statistic='mean'):
         """
         Parameters:
         -----------
-        rowsize,colsize: int
-            shape of image in pixels.
+        shape: tuple of ints of length 2.
+            shape of image.
         bins : int or sequence of scalars, optional
             If `bins` is an int, it defines the number of equal-width bins in
             the given range (10 by default).  If `bins` is a sequence, it
@@ -509,9 +515,9 @@ class RadialBinnedStatistic(BinnedStatistic1D):
             The lower and upper range of the bins.  If not provided, range
             is simply ``(x.min(), x.max())``.  Values outside the range are
             ignored.
-        rowc,colc: int, optional
+        origin: tuple of ints with length 2, optional
             location (in pixels) of origin (default: image center).
-        mask: 2-dimensional np.ndarray, optional
+        mask: 2-dimensional np.ndarray of ints, optional
             array of zero/non-zero values, same shape as image used
             in __call__.  zero values will be ignored.
         statistic : string or callable, optional
@@ -532,7 +538,7 @@ class RadialBinnedStatistic(BinnedStatistic1D):
                 will be called on the values in each bin.  Empty bins will be
                 represented by function([]), or NaN if this returns an error.
         """
-        rpix, _ = get_r_phi(rowsize, colsize, rowc, colc)
+        rpix, _ = get_r_phi(shape, origin)
         self.expected_shape = rpix.shape
 
         if mask is not None:

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -426,7 +426,7 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
         """
         Parameters:
         -----------
-        shape: tuple of ints of length 2.
+        shape : tuple of ints of length 2.
             shape of image.
         bins : int or [int, int] or array_like or [array, array], optional
             The bin specification:
@@ -443,9 +443,9 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
             [[rmin, rmax], [phimin, phimax]]. All values outside of this range
             will be considered outliers and not tallied in the histogram.
             See "bins" parameter for definition of phi.
-        origin: tuple of ints with length 2, optional
+        origin : tuple of ints with length 2, optional
             location (in pixels) of origin (default: image center).
-        mask: 2-dimensional np.ndarray of ints, optional
+        mask : 2-dimensional np.ndarray of ints, optional
             array of zero/non-zero values, same shape as image used
             in __call__.  zero values will be ignored.
         statistic : string or callable, optional
@@ -493,8 +493,8 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
 
 class RadialBinnedStatistic(BinnedStatistic1D):
     """
-    Create a 2-dimensional histogram by binning a 2-dimensional
-    image in both radius and phi.
+    Create a 1-dimensional histogram by binning a 2-dimensional
+    image in radius.
     """
 
     def __init__(self, shape, bins=10, range=None,
@@ -511,10 +511,14 @@ class RadialBinnedStatistic(BinnedStatistic1D):
             non-uniform bin widths.  Values in `x` that are smaller than lowest
             bin edge are assigned to bin number 0, values beyond the highest
             bin are assigned to ``bins[-1]``.
+            Phi has a range of -pi to pi and is defined as arctan(col/row)
+            (i.e. y is column and x is row, or "matrix" format,
+            not "cartesian")
         range : (float, float) or [(float, float)], optional
             The lower and upper range of the bins.  If not provided, range
             is simply ``(x.min(), x.max())``.  Values outside the range are
             ignored.
+            See "bins" parameter for definition of phi.
         origin: tuple of ints with length 2, optional
             location (in pixels) of origin (default: image center).
         mask: 2-dimensional np.ndarray of ints, optional

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -70,7 +70,9 @@ class BinnedStatisticDD(object):
             A sequence of lower and upper bin edges to be used if the
             edges are not given explicitely in `bins`. Defaults to the
             minimum and maximum values along each dimension.
-
+        mask : array_like
+            array of ones and zeros with the same shape as `sample`.
+            Values with mask==0 will be ignored.
         """
         if mask is None:
             mask = np.ones_like(sample)
@@ -292,6 +294,9 @@ class BinnedStatistic1D(BinnedStatisticDD):
             The lower and upper range of the bins.  If not provided, range
             is simply ``(x.min(), x.max())``.  Values outside the range are
             ignored.
+        mask : array_like
+            array of ones and zeros with the same shape as `x`.
+            Values with mask==0 will be ignored.
 
         See Also
         --------
@@ -370,6 +375,9 @@ class BinnedStatistic2D(BinnedStatisticDD):
         (if not specified explicitly in the `bins` parameters):
         [[xmin, xmax], [ymin, ymax]]. All values outside of this range will be
         considered outliers and not tallied in the histogram.
+    mask : array_like
+        array of ones and zeros with the same shape as `x`.
+        Values with mask==0 will be ignored.
 
     See Also
     --------

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -295,7 +295,7 @@ class BinnedStatistic1D(BinnedStatisticDD):
             is simply ``(x.min(), x.max())``.  Values outside the range are
             ignored.
         mask : array_like
-            array of ones and zeros with the same shape as `x`.
+            ones and zeros with the same shape as `x`.
             Values with mask==0 will be ignored.
 
         See Also
@@ -376,7 +376,7 @@ class BinnedStatistic2D(BinnedStatisticDD):
         [[xmin, xmax], [ymin, ymax]]. All values outside of this range will be
         considered outliers and not tallied in the histogram.
     mask : array_like
-        array of ones and zeros with the same shape as `x`.
+        ones and zeros with the same shape as `x`.
         Values with mask==0 will be ignored.
 
     See Also
@@ -454,8 +454,8 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
         origin : tuple of ints with length 2, optional
             location (in pixels) of origin (default: image center).
         mask : 2-dimensional np.ndarray of ints, optional
-            array of zero/non-zero values, same shape as image used
-            in __call__.  zero values will be ignored.
+            array of zero/non-zero values, with shape `shape`.
+            zero values will be ignored.
         statistic : string or callable, optional
             The statistic to compute (default is 'mean').
             The following statistics are available:
@@ -476,7 +476,7 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
         """
         rpix, phipix = get_r_phi(shape, origin)
 
-        self.expected_shape = rpix.shape
+        self.expected_shape = shape
         if mask is not None:
             if mask.shape != self.expected_shape:
                 raise ValueError('"mask" has incorrect shape. '
@@ -510,7 +510,7 @@ class RadialBinnedStatistic(BinnedStatistic1D):
         """
         Parameters:
         -----------
-        shape: tuple of ints of length 2.
+        shape : tuple of ints of length 2.
             shape of image.
         bins : int or sequence of scalars, optional
             If `bins` is an int, it defines the number of equal-width bins in
@@ -527,11 +527,11 @@ class RadialBinnedStatistic(BinnedStatistic1D):
             is simply ``(x.min(), x.max())``.  Values outside the range are
             ignored.
             See "bins" parameter for definition of phi.
-        origin: tuple of ints with length 2, optional
+        origin : tuple of ints with length 2, optional
             location (in pixels) of origin (default: image center).
-        mask: 2-dimensional np.ndarray of ints, optional
-            array of zero/non-zero values, same shape as image used
-            in __call__.  zero values will be ignored.
+        mask : 2-dimensional np.ndarray of ints, optional
+            array of zero/non-zero values, with shape `shape`.
+            zero values will be ignored.
         statistic : string or callable, optional
             The statistic to compute (default is 'mean').
             The following statistics are available:
@@ -551,7 +551,7 @@ class RadialBinnedStatistic(BinnedStatistic1D):
                 represented by function([]), or NaN if this returns an error.
         """
         rpix, _ = get_r_phi(shape, origin)
-        self.expected_shape = rpix.shape
+        self.expected_shape = shape
 
         if mask is not None:
             if mask.shape != self.expected_shape:

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -134,12 +134,13 @@ class BinnedStatisticDD(object):
         # Compute the bin number each sample falls into.
         Ncount = {}
         for i in np.arange(self.D):
-            # Apply mask in a non-ideal way by setting value outside range
+            # Apply mask in a non-ideal way by setting value outside range.
+            # Would be better to do this using bincount "weights"
             thissample = sample[:, i]
             thismask = mask[:, i]
             thissample[thismask == 0] = (self.edges[i][0] -
-                                         0.01 * np.fabs(self.edges[i][0]))
-            Ncount[i] = np.digitize(sample[:, i], self.edges[i])
+                                         0.01 * (1+np.fabs(self.edges[i][0])))
+            Ncount[i] = np.digitize(thissample, self.edges[i])
 
         # Using digitize, values that fall on an edge are put in the
         # right bin.  For the rightmost bin, we want values equal to
@@ -472,6 +473,7 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
                                                   phipix.reshape(-1),
                                                   statistic,
                                                   bins=bins,
+                                                  mask=mask.reshape(-1),
                                                   range=range)
 
     def __call__(self, values):
@@ -542,6 +544,7 @@ class RadialBinnedStatistic(BinnedStatistic1D):
         super(RadialBinnedStatistic, self).__init__(rpix.reshape(-1),
                                                     statistic,
                                                     bins=bins,
+                                                    mask=mask.reshape(-1),
                                                     range=range)
 
     def __call__(self, values):

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -396,22 +396,25 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
         """
         Parameters:
         -----------
-        rbins: int
-            number of radial bins in returned histogram.
-        phibins: int
-            number of phi bins in returned histogram.
         rowsize,colsize: int
             shape of image in pixels.
+        bins : int or [int, int] or array_like or [array, array], optional
+            The bin specification:
+            * number of bins for the two dimensions (nr=nphi=bins),
+            * number of bins in each dimension (nr, nphi = bins),
+            * bin edges for the two dimensions (r_edges = phi_edges = bins),
+            * the bin edges in each dimension (r_edges, phi_edges = bins).
+            Phi has a range of -pi to pi and is defined as arctan(col/row)
+            (i.e. y is column and x is row, or "matrix" format,
+            not "cartesian")
+        range : (2,2) array_like, optional
+            The leftmost and rightmost edges of the bins along each dimension
+            (if not specified explicitly in the `bins` parameters):
+            [[rmin, rmax], [phimin, phimax]]. All values outside of this range
+            will be considered outliers and not tallied in the histogram.
+            See "bins" parameter for definition of phi.
         rowc,colc: int, optional
             location (in pixels) of origin (default: image center).
-        rrange: (float, float), optional
-            The lower and upper radial range of the bins, in pixels.
-            If not provided, all pixel r values are included.
-        phirange: (float, float), optional
-            phi range to include.  Values are in the range
-            (-pi,pi) radians (default: no limits).  Phi is
-            computed as arctan(col/row), i.e. "matrix" ordering and
-            not "cartesian" ordering.
         mask: 2-dimensional np.ndarray, optional
             array of zero/non-zero values, same shape as image used
             in __call__.  zero values will be ignored.

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -135,7 +135,7 @@ class BinnedStatisticDD(object):
         Ncount = {}
         for i in np.arange(self.D):
             # Apply mask in a non-ideal way by setting value outside range.
-            # Would be better to do this using bincount "weights"
+            # Would be better to do this using bincount "weights", perhaps.
             thissample = sample[:, i]
             thismask = mask[:, i]
             thissample[thismask == 0] = (self.edges[i][0] -

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -466,7 +466,7 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
                 will be called on the values in each bin.  Empty bins will be
                 represented by function([]), or NaN if this returns an error.
         """
-        rpix, phipix = get_r_phi(rowsize, colsize, origin)
+        rpix, phipix = get_r_phi(shape, origin)
 
         self.expected_shape = rpix.shape
         if mask is not None:

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -391,9 +391,8 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
     image in both radius and phi.
     """
 
-    def __init__(self, rbins, phibins, rowsize, colsize,
-                 rowc=None, colc=None, rrange=None, phirange=None, mask=None,
-                 statistic='mean'):
+    def __init__(self, rowsize, colsize, bins=10, range=None,
+                 rowc=None, colc=None, mask=None, statistic='mean'):
         """
         Parameters:
         -----------
@@ -447,23 +446,20 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
 
         phipix = np.arctan2(colgrid, rowgrid)
 
-        if rrange is None:
-            rrange = (rpix.min(), rpix.max())
-        if phirange is None:
-            phirange = (-np.pi, np.pi)
         if mask is not None:
             if mask.shape != self.expected_shape:
                 raise ValueError('"mask" has incorrect shape. '
                                  ' Expected: ' + str(self.expected_shape) +
                                  ' Received: ' + str(mask.shape))
             # a somewhat ugly way to mask pixels
-            rpix[mask == 0] = rrange[0]-1
+            # need to bury this in lower level class
+            # rpix[mask == 0] = rrange[0]-1
 
         super(RPhiBinnedStatistic, self).__init__(rpix.reshape(-1),
                                                   phipix.reshape(-1),
                                                   statistic,
-                                                  bins=(rbins, phibins),
-                                                  range=(rrange, phirange))
+                                                  bins=bins,
+                                                  range=range)
 
     def __call__(self, values):
         # check for what I believe could be a common error
@@ -480,17 +476,17 @@ class RadialBinnedStatistic(RPhiBinnedStatistic):
     image in radius.
     """
 
-    def __init__(self, bins, rowsize, colsize,
-                 rowc=None, colc=None, rrange=None, phirange=None, mask=None,
+    def __init__(self, rowsize, colsize, bins=10, range=None,
+                 rowc=None, colc=None, mask=None,
                  statistic='mean'):
         """
         See RPhiBinnedStatistic documentation.
         """
 
-        super(RadialBinnedStatistic, self).__init__(bins, 1, rowsize, colsize,
+        super(RadialBinnedStatistic, self).__init__(rowsize, colsize,
+                                                    (bins, 1), range,
                                                     rowc, colc,
-                                                    rrange, phirange, mask,
-                                                    statistic)
+                                                    mask, statistic)
 
     def __call__(self, values):
         return np.squeeze(super(RadialBinnedStatistic, self).__call__(values))

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -94,9 +94,6 @@ class BinnedStatisticDD(object):
             sample = np.atleast_2d(sample).T
             N, self.D = sample.shape
 
-        if mask is None:
-            mask = np.ones((N))
-
         self.nbin = np.empty(self.D, int)
         self.edges = self.D * [None]
         dedges = self.D * [None]
@@ -144,8 +141,9 @@ class BinnedStatisticDD(object):
             # Apply mask in a non-ideal way by setting value outside range.
             # Would be better to do this using bincount "weights", perhaps.
             thissample = sample[:, i]
-            thissample[mask == 0] = (self.edges[i][0] -
-                                     0.01 * (1+np.fabs(self.edges[i][0])))
+            if mask is not None:
+                thissample[mask == 0] = (self.edges[i][0] -
+                                         0.01 * (1+np.fabs(self.edges[i][0])))
             Ncount[i] = np.digitize(thissample, self.edges[i])
 
         # Using digitize, values that fall on an edge are put in the
@@ -428,9 +426,9 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
             * number of bins in each dimension (nr, nphi = bins),
             * bin edges for the two dimensions (r_edges = phi_edges = bins),
             * the bin edges in each dimension (r_edges, phi_edges = bins).
-            Phi has a range of -pi to pi and is defined as arctan(col/row)
-            (i.e. y is column and x is row, or "matrix" format,
-            not "cartesian")
+            Phi has a range of -pi to pi and is defined as arctan(row/col)
+            (i.e. x is column and y is row, or "cartesian" format,
+            not "matrix")
         range : (2,2) array_like, optional
             The leftmost and rightmost edges of the bins along each dimension
             (if not specified explicitly in the `bins` parameters):
@@ -510,9 +508,9 @@ class RadialBinnedStatistic(BinnedStatistic1D):
             non-uniform bin widths.  Values in `x` that are smaller than lowest
             bin edge are assigned to bin number 0, values beyond the highest
             bin are assigned to ``bins[-1]``.
-            Phi has a range of -pi to pi and is defined as arctan(col/row)
-            (i.e. y is column and x is row, or "matrix" format,
-            not "cartesian")
+            Phi has a range of -pi to pi and is defined as arctan(row/col)
+            (i.e. x is column and y is row, or "cartesian" format,
+            not "matrix")
         range : (float, float) or [(float, float)], optional
             The lower and upper range of the bins.  If not provided, range
             is simply ``(x.min(), x.max())``.  Values outside the range are

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -28,17 +28,17 @@ class TestRadialBinnedStatistic(object):
 
     def testRadialBinnedStatistic(self):
 
-        mykwargs = [{'rowc': 0, 'colc': 0, 'rrange': (10, 90),
-                     'phirange': (np.deg2rad(5), np.deg2rad(60))},
+        mykwargs = [{'rowc': 0, 'colc': 0,
+                     'range': ((10, 90), (-np.pi, np.pi))},
                     {'rowc': 0, 'colc': 0}]
         bins, rowsize, colsize = 100, self.image.shape[0], self.image.shape[1]
         for kwargs in mykwargs:
             for stat, stat_func in stats_list:
 
-                radbinstat = RadialBinnedStatistic(bins, rowsize, colsize,
+                radbinstat = RadialBinnedStatistic(rowsize, colsize, bins,
                                                    statistic=stat,
                                                    **kwargs)
-                radbinstat_f = RadialBinnedStatistic(bins, rowsize, colsize,
+                radbinstat_f = RadialBinnedStatistic(rowsize, colsize, bins,
                                                      statistic=stat_func,
                                                      **kwargs)
                 binned = radbinstat(self.image)
@@ -47,27 +47,27 @@ class TestRadialBinnedStatistic(object):
                 assert_array_almost_equal(binned_f, binned)
                 # can't check equality if we use normalization with
                 # current testing strategy, but at least check code runs
-                if 'phirange' not in kwargs:
-                    rrange = kwargs.get('rrange', None)
-                    ref, edges, _ = scipy.stats.binned_statistic(
-                        x=self.rgrid.ravel(),
-                        values=self.image.ravel(),
-                        statistic=stat,
-                        range=rrange,
-                        bins=bins,
-                    )
 
-                    assert_array_equal(ref, binned)
-                    assert_array_equal(edges, radbinstat.bin_edges[0])
-                    assert_array_equal(edges, radbinstat_f.bin_edges[0])
+                rrange = kwargs.get('range', None)
+                if rrange is not None: rrange=rrange[0]
+                ref, edges, _ = scipy.stats.binned_statistic(
+                    x=self.rgrid.ravel(),
+                    values=self.image.ravel(),
+                    statistic=stat,
+                    range=rrange,
+                    bins=bins,
+                )
+
+                assert_array_equal(ref, binned)
+                assert_array_equal(edges, radbinstat.bin_edges[0])
+                assert_array_equal(edges, radbinstat_f.bin_edges[0])
         # test exception when BinnedStatistic is given array of incorrect shape
         with assert_raises(ValueError):
             radbinstat(self.image[:10, :10])
 
         # test exception when RadialBinnedStatistic is given 1D array
         with assert_raises(ValueError):
-            RadialBinnedStatistic(10,
-                                  self.image.shape[0], self.image.shape[1],
+            RadialBinnedStatistic(self.image.shape[0], self.image.shape[1], 10,
                                   mask=np.array([1, 2, 3, 4]))
 
 

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -1,4 +1,5 @@
 from skbeam.core.accumulators.binned_statistic import (RadialBinnedStatistic,
+                                                       RPhiBinnedStatistic,
                                                        BinnedStatistic1D)
 from nose.tools import assert_raises
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -23,6 +24,7 @@ class TestRadialBinnedStatistic(object):
         colarr = np.arange(colsize)
         rowgrid, colgrid = np.meshgrid(rowarr, colarr, indexing='ij')
         self.rgrid = np.sqrt(rowgrid**2 + colgrid**2)
+        self.phigrid = np.arctan2(colgrid, rowgrid)
 
         self.image = np.sinc(self.rgrid / self.oscillation_rate)
 
@@ -34,6 +36,7 @@ class TestRadialBinnedStatistic(object):
         bins, shape = 100, self.image.shape
         mask_ones = np.ones_like(self.image)
         mask_random = np.random.randint(2, size=self.image.shape)
+
         for kwargs in mykwargs:
             for stat, stat_func in stats_list:
 
@@ -44,6 +47,7 @@ class TestRadialBinnedStatistic(object):
                 else:
                     mask = mask_ones
 
+                # test radial case
                 radbinstat = RadialBinnedStatistic(shape, bins,
                                                    statistic=stat,
                                                    mask=mask,
@@ -56,21 +60,69 @@ class TestRadialBinnedStatistic(object):
                 binned_f = radbinstat_f(self.image)
 
                 assert_array_almost_equal(binned_f, binned)
-                # can't check equality if we use normalization with
-                # current testing strategy, but at least check code runs
 
-                range = kwargs.get('range', None)
+                kwrange = kwargs.get('range', None)
                 ref, edges, _ = scipy.stats.binned_statistic(
                     x=self.rgrid.ravel(),
                     values=(self.image*mask).ravel(),
                     statistic=stat,
-                    range=range,
+                    range=kwrange,
                     bins=bins,
                 )
 
                 assert_array_equal(ref, binned)
                 assert_array_equal(edges, radbinstat.bin_edges[0])
                 assert_array_equal(edges, radbinstat_f.bin_edges[0])
+
+        bins = (100, 2)
+        myrphikwargs = [{'origin': (0, 0),
+                         'range': ((10, 90), (0, np.pi/2))},
+                        {'origin': (0, 0)}]
+        for kwargs in myrphikwargs:
+            for stat, stat_func in stats_list:
+
+                if stat is 'sum':
+                    # in this case we can compare our masked
+                    # result to binned_statistic
+                    mask = mask_random
+                else:
+                    mask = mask_ones
+
+                # test radial case
+                rphibinstat = RPhiBinnedStatistic(shape, bins,
+                                                  statistic=stat,
+                                                  mask=mask,
+                                                  **kwargs)
+                rphibinstat_f = RPhiBinnedStatistic(shape, bins,
+                                                    statistic=stat_func,
+                                                    mask=mask,
+                                                    **kwargs)
+                binned = rphibinstat(self.image)
+                binned_f = rphibinstat_f(self.image)
+
+                # this test fails only for the standard deviation where
+                # there is a disagreement in the number of nan's.  I
+                # don't believe this is the fault of the binned_statistic
+                # code
+                if stat != 'std':
+                    assert_array_almost_equal(binned_f, binned)
+
+                kwrange = kwargs.get('range', None)
+                ref, redges, phiedges, _ = scipy.stats.binned_statistic_2d(
+                    x=self.rgrid.ravel(),
+                    y=self.phigrid.ravel(),
+                    values=(self.image*mask).ravel(),
+                    statistic=stat,
+                    range=kwrange,
+                    bins=bins,
+                )
+
+                assert_array_equal(ref, binned)
+                assert_array_equal(redges, rphibinstat.bin_edges[0])
+                assert_array_equal(redges, rphibinstat_f.bin_edges[0])
+                assert_array_equal(phiedges, rphibinstat.bin_edges[1])
+                assert_array_equal(phiedges, rphibinstat_f.bin_edges[1])
+
         # test exception when BinnedStatistic is given array of incorrect shape
         with assert_raises(ValueError):
             radbinstat(self.image[:10, :10])

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -28,10 +28,10 @@ class TestRadialBinnedStatistic(object):
 
     def testRadialBinnedStatistic(self):
 
-        mykwargs = [{'rowc': 0, 'colc': 0,
+        mykwargs = [{'origin': (0, 0),
                      'range': (10, 90)},
-                    {'rowc': 0, 'colc': 0}]
-        bins, rowsize, colsize = 100, self.image.shape[0], self.image.shape[1]
+                    {'origin': (0, 0)}]
+        bins, shape = 100, self.image.shape
         mask_ones = np.ones_like(self.image)
         mask_random = np.random.randint(2, size=self.image.shape)
         for kwargs in mykwargs:
@@ -44,11 +44,11 @@ class TestRadialBinnedStatistic(object):
                 else:
                     mask = mask_ones
 
-                radbinstat = RadialBinnedStatistic(rowsize, colsize, bins,
+                radbinstat = RadialBinnedStatistic(shape, bins,
                                                    statistic=stat,
                                                    mask=mask,
                                                    **kwargs)
-                radbinstat_f = RadialBinnedStatistic(rowsize, colsize, bins,
+                radbinstat_f = RadialBinnedStatistic(shape, bins,
                                                      statistic=stat_func,
                                                      mask=mask,
                                                      **kwargs)
@@ -77,7 +77,7 @@ class TestRadialBinnedStatistic(object):
 
         # test exception when RadialBinnedStatistic is given 1D array
         with assert_raises(ValueError):
-            RadialBinnedStatistic(self.image.shape[0], self.image.shape[1], 10,
+            RadialBinnedStatistic(self.image.shape, 10,
                                   mask=np.array([1, 2, 3, 4]))
 
 

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -29,7 +29,7 @@ class TestRadialBinnedStatistic(object):
     def testRadialBinnedStatistic(self):
 
         mykwargs = [{'rowc': 0, 'colc': 0,
-                     'range': ((10, 90), (-np.pi, np.pi))},
+                     'range': (10, 90)},
                     {'rowc': 0, 'colc': 0}]
         bins, rowsize, colsize = 100, self.image.shape[0], self.image.shape[1]
         for kwargs in mykwargs:
@@ -48,14 +48,12 @@ class TestRadialBinnedStatistic(object):
                 # can't check equality if we use normalization with
                 # current testing strategy, but at least check code runs
 
-                rrange = kwargs.get('range', None)
-                if rrange is not None:
-                    rrange = rrange[0]
+                range = kwargs.get('range', None)
                 ref, edges, _ = scipy.stats.binned_statistic(
                     x=self.rgrid.ravel(),
                     values=self.image.ravel(),
                     statistic=stat,
-                    range=rrange,
+                    range=range,
                     bins=bins,
                 )
 

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -49,7 +49,8 @@ class TestRadialBinnedStatistic(object):
                 # current testing strategy, but at least check code runs
 
                 rrange = kwargs.get('range', None)
-                if rrange is not None: rrange=rrange[0]
+                if rrange is not None:
+                    rrange = rrange[0]
                 ref, edges, _ = scipy.stats.binned_statistic(
                     x=self.rgrid.ravel(),
                     values=self.image.ravel(),

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -32,14 +32,25 @@ class TestRadialBinnedStatistic(object):
                      'range': (10, 90)},
                     {'rowc': 0, 'colc': 0}]
         bins, rowsize, colsize = 100, self.image.shape[0], self.image.shape[1]
+        mask_ones = np.ones_like(self.image)
+        mask_random = np.random.randint(2, size=self.image.shape)
         for kwargs in mykwargs:
             for stat, stat_func in stats_list:
 
+                if stat is 'sum':
+                    # in this case we can compare our masked
+                    # result to binned_statistic
+                    mask = mask_random
+                else:
+                    mask = mask_ones
+
                 radbinstat = RadialBinnedStatistic(rowsize, colsize, bins,
                                                    statistic=stat,
+                                                   mask=mask,
                                                    **kwargs)
                 radbinstat_f = RadialBinnedStatistic(rowsize, colsize, bins,
                                                      statistic=stat_func,
+                                                     mask=mask,
                                                      **kwargs)
                 binned = radbinstat(self.image)
                 binned_f = radbinstat_f(self.image)
@@ -51,7 +62,7 @@ class TestRadialBinnedStatistic(object):
                 range = kwargs.get('range', None)
                 ref, edges, _ = scipy.stats.binned_statistic(
                     x=self.rgrid.ravel(),
-                    values=self.image.ravel(),
+                    values=(self.image*mask).ravel(),
                     statistic=stat,
                     range=range,
                     bins=bins,


### PR DESCRIPTION
As I discussed previously with Tom, I realized that the binning specification in the RPhiBinnedStatistic and RadialBinnedStatistic was not as flexible as what was underneath in the scipy binned_statistic code.  This PR tries to address that.  Over the course of doing this, it became clear that my inheritance wasn't structured correctly, so I tried to fix that.

There are three things that seem non-ideal to me:

- the way I implement masking (which is not available in scipy.binned_statistic) is imperfect, but it's the best I can see at the moment.  see comments in code
- there are about 10 lines of code that are duplicated in both RPhiBinnedStatistic and RadialBinnedStatistic.  I might be able to fix this with some inheritance or fancy python tricks
- I should test RPhiBinnedStatistic using scipy.binned_statistic_2d

But this PR improves the interface, which is important.

p.s. this time I started out with a fresh fork/clone and did the "magic 4 commands" that Tom sent me to create the feature-branch.  So hopefully there will not be git issues this time.  Learning.