### PR TITLE
don't use scipy._lib.six callable

### DIFF
--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -39,7 +39,6 @@ from __future__ import division, print_function, absolute_import
 import warnings
 
 import numpy as np
-from scipy._lib.six import callable
 from ..utils import radial_grid, angle_grid
 
 


### PR DESCRIPTION
As discussed with Tom, this one line was brought in from scipy binned_statistic to support the fact that "callable" is not available in python 3.1.  That's an old version which we don't need to support.  Removing this line enables more people to use skbeam's binned_statistic because some versions of scipy don't have scipy._lib.six.