### PR TITLE
Fix 1d

### DIFF
--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -567,6 +567,22 @@ class RadialBinnedStatistic(BinnedStatistic1D):
                                                     mask=mask,
                                                     range=range)
 
+    @property
+    def bin_edges(self):
+        """
+        bin_edges : 1D array of dtype float
+        Return the bin edges.
+        """
+        return super(RadialBinnedStatistic, self).bin_edges[0]
+
+    @property
+    def bin_centers(self):
+        """
+        bin_centers : 1D array of dtype float
+        Return the bin centers.
+        """
+        return super(RadialBinnedStatistic, self).bin_centers[0]
+
     def __call__(self, values):
         # check for what I believe could be a common error
         if values.shape != self.expected_shape:

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -336,6 +336,22 @@ class BinnedStatistic1D(BinnedStatisticDD):
                                                 bins=bins, range=range,
                                                 mask=mask)
 
+    @property
+    def bin_edges(self):
+        """
+        bin_edges : 1D array of dtype float
+        Return the bin edges.
+        """
+        return super(BinnedStatistic1D, self).bin_edges[0]
+
+    @property
+    def bin_centers(self):
+        """
+        bin_centers : 1D array of dtype float
+        Return the bin centers.
+        """
+        return super(BinnedStatistic1D, self).bin_centers[0]
+
 
 class BinnedStatistic2D(BinnedStatisticDD):
     """
@@ -566,22 +582,6 @@ class RadialBinnedStatistic(BinnedStatistic1D):
                                                     bins=bins,
                                                     mask=mask,
                                                     range=range)
-
-    @property
-    def bin_edges(self):
-        """
-        bin_edges : 1D array of dtype float
-        Return the bin edges.
-        """
-        return super(RadialBinnedStatistic, self).bin_edges[0]
-
-    @property
-    def bin_centers(self):
-        """
-        bin_centers : 1D array of dtype float
-        Return the bin centers.
-        """
-        return super(RadialBinnedStatistic, self).bin_centers[0]
 
     def __call__(self, values):
         # check for what I believe could be a common error

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -150,5 +150,5 @@ def test_BinnedStatistics1D():
 
         assert_array_equal(bs(values), ref)
         assert_array_almost_equal(bs_f(values), ref)
-        assert_array_equal(edges, bs.bin_edges[0])
-        assert_array_equal(edges, bs_f.bin_edges[0])
+        assert_array_equal(edges, bs.bin_edges)
+        assert_array_equal(edges, bs_f.bin_edges)

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -73,10 +73,10 @@ class TestRadialBinnedStatistic(object):
                 centers = bin_edges_to_centers(edges)
 
                 assert_array_equal(ref, binned)
-                assert_array_equal(edges, radbinstat.bin_edges[0])
-                assert_array_equal(edges, radbinstat_f.bin_edges[0])
-                assert_array_equal(centers, radbinstat.bin_centers[0])
-                assert_array_equal(centers, radbinstat_f.bin_centers[0])
+                assert_array_equal(edges, radbinstat.bin_edges)
+                assert_array_equal(edges, radbinstat_f.bin_edges)
+                assert_array_equal(centers, radbinstat.bin_centers)
+                assert_array_equal(centers, radbinstat_f.bin_centers)
 
         bins = (100, 2)
         myrphikwargs = [{'origin': (0, 0),


### PR DESCRIPTION
Hey everyone,

I believe I made an error in the BinnedStatistic1D interface for edges/centers:  I believe for the one-dimensional case it is more intuitive for users if they do not use bin_edges[0] but instead use the simpler bin_edges.  You can see it makes the testing code cleaner, for example.