### PR TITLE
forced mask to be bool in auto masking

### DIFF
--- a/skbeam/core/mask.py
+++ b/skbeam/core/mask.py
@@ -150,7 +150,7 @@ def binned_outlier(img, r, alpha, bins, mask=None):
         then we just use that as the distribution of alphas
     bins: list
         The bin edges
-    mask: 1darray
+    mask: 1darray, bool
         A starting flattened mask
 
     Returns
@@ -162,7 +162,7 @@ def binned_outlier(img, r, alpha, bins, mask=None):
     if mask is None:
         working_mask = np.ones(img.shape).astype(bool)
     else:
-        working_mask = mask.copy()
+        working_mask = np.copy(mask).astype(bool)
     if working_mask.shape != img.shape:
         working_mask = working_mask.reshape(img.shape)
     msk_img = img[working_mask]


### PR DESCRIPTION
I was testing this function and found that if the mask is an array of integers it crashes. The following line fixes the event that the user inputs an integer mask. At the very least, it should be indicated in the documentation that a bool mask is required. Other than that it seems to work (thanks @CJ-Wright )

@CJ-Wright 
( @tacaswell @danielballan )

details:
Basically, in numpy, say you have a mask array, calling:
```python
img[mask]
```
seems to  lead to two very different cases when mask is of dtype bool versus int. The latter can lead to memory errors (if each entry in `mask` is treated as a row rather than a point). I haven't had time to understand it fully, but as far as I can tell, mask being anything other than a np.ndarray of bools seems to lead to inconsistent results.

(for example, array `a`, here are some results:
```ipython
In [17]: a  = np.ones((10,10))

In [18]: a[[2,2]]
Out[18]: 
array([[ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
       [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.]])

In [19]: a[[[2,2],[1,2]]]
Out[19]: array([ 1.,  1.])

In [20]: a[np.array([[2,2],[1,2]])]
Out[20]: 
array([[[ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
        [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.]],

       [[ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.],
        [ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.]]])
```