### PR TITLE
Spatial Correlations

### DIFF
--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -942,6 +942,9 @@ class CrossCorrelator:
         self.tmpimgs = list()
         self.tmpimgs2 = list()
         self.centers = list()
+        self.shapes = list()  # the shapes of each correlation
+        # the positions of each axes of each correlation
+        self.positions = list()
 
         self.ids = np.sort(np.unique(mask))
         # remove the zero since we ignore, but only if it is there (sometimes
@@ -980,7 +983,21 @@ class CrossCorrelator:
             self.maskcorrs.append(maskcorr)
             self.pxlst_maskcorrs.append(maskcorr > 0)
             # centers are shape//2 as performed by fftshift
+            center = np.array(maskcorr.shape)//2
             self.centers.append(np.array(maskcorr.shape)//2)
+            self.shapes.append(np.array(maskcorr.shape))
+            if mask.ndim == 1:
+                self.positions.append(np.arange(maskcorr.shape[0]) - center[0])
+            elif mask.ndim == 2:
+                self.positions.append([np.arange(maskcorr.shape[0]) -
+                                       center[0],
+                                       np.arange(maskcorr.shape[1]) -
+                                       center[1]])
+
+        if len(self.ids) == 1:
+            self.positions = self.positions[0]
+            self.centers = self.centers[0]
+            self.shapes = self.shapes[0]
 
     def __call__(self, img1, img2=None, normalization=None):
         ''' Run the cross correlation on an image/curve or against two
@@ -1056,8 +1073,8 @@ class CrossCorrelator:
                 # only run on overlapping regions for correlation
                 w = self.pxlst_maskcorrs[i]
                 ccorr[w] /= self.maskcorrs[i][w] * \
-                            np.average(self.tmpimgs[i].
-                                       ravel()[self.subpxlsts[i]])**2
+                    np.average(self.tmpimgs[i].
+                               ravel()[self.subpxlsts[i]])**2
 
             ccorrs.append(ccorr)
 

--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -1070,7 +1070,7 @@ def _cross_corr(img1, img2=None):
 
         Parameters
         ----------
-        img1 : 1d or 2d np.ndarray
+        img1 : np.ndarray
             the image or curve to cross correlate
 
         img2 : 1d or 2d np.ndarray, optional
@@ -1090,7 +1090,10 @@ def _cross_corr(img1, img2=None):
             .format(*img1.shape, *img2.shape)
         raise ValueError(errorstr)
 
-    reverse_index = (*((slice(None, None, -1),)*ndim),)
+    # need to reverse indices for second image
+    # fftconvolve(A,B) = FFT^(-1)(FFT(A)*FFT(B))
+    # but need FFT^(-1)(FFT(A(x))*conj(FFT(B(x)))) = FFT^(-1)(A(x)*B(-x))
+    reverse_index = [slice(None, None, -1) for i in range(ndim)]
     imgc = fftconvolve(img1, img2[reverse_index], mode='same')
 
     return imgc

--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -1085,7 +1085,7 @@ def _cross_corr(img1, img2=None):
         errorstr = "Image shapes don't match. "
         errorstr += "(img1 : {},{}; img2 : {},{})"\
             .format(*img1.shape, *img2.shape)
-        raise ValueError()
+        raise ValueError(errorstr)
 
     reverse_index = (*((slice(None, None, -1),)*ndim),)
     imgc = fftconvolve(img1, img2[reverse_index], mode='same')

--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -869,11 +869,14 @@ class CrossCorrelator:
 
         >> ccorr = CrossCorrelator(mask.shape, mask=mask)
         >> # correlated image
-        >> cimg = cc(img)
+        >> cimg = cc(img1)
         or, mask may m
         >> cc = CrossCorrelator(ids)
-        #(where ids is same shape as img)
-        >> cc1 = cc(img)
+        #(where ids is same shape as img1)
+        >> cc1 = cc(img1)
+        >> cc12 = cc(img1, img2)
+        # if img2 shifts right of img1, point of maximum correlation is shifted
+        # right from correlation center
 
         References
         ----------
@@ -1096,19 +1099,20 @@ def _cross_corr(img1, img2=None):
 def _crop_from_mask(mask):
     '''
         Crop an image from a given mask
-        returns the sub-selected pixels, as well as the new masked image
 
         Parameters
         ----------
+
         mask : 1d or 2d np.ndarray
             The data to be cropped. This consists of integers >=0.
             Regions with 0 are masked and regions > 1 are kept.
 
-       Returns
-       -------
-       mask : 1d or 2d np.ndarray
-           The cropped image. This image is cropped as much as possible
-           without losing unmasked data.
+        Returns
+        -------
+
+        mask : 1d or 2d np.ndarray
+            The cropped image. This image is cropped as much as possible
+            without losing unmasked data.
     '''
     dims = mask.shape
     pxlst = np.where(mask.ravel() != 0)[0]
@@ -1139,8 +1143,7 @@ def _crop_from_mask(mask):
 
 
 def _expand_image(img):
-    ''' Convenience routine to make an image with twice the size, plus
-            one.
+    ''' Convenience routine to make an image with twice the size, plus one.
 
         Parameters
         ----------

--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -1036,8 +1036,6 @@ class CrossCorrelator:
             else:
                 ccorr = _cross_corr(self.tmpimgs[i], self.tmpimgs2[i]) * \
                         (self.maskcorrs[i] > 0)
-            # only select valid regions
-            w = self.pxlst_maskcorrs[i]
 
             # now handle the normalizations
             if 'symavg' in normalization:
@@ -1050,9 +1048,13 @@ class CrossCorrelator:
                 else:
                     Icorr2 = _cross_corr(self.submasks[i], self.tmpimgs2[i] *
                                          self.submasks[i])
+                # there is an extra condition that Icorr*Icorr2 != 0
+                w = np.where(np.abs(Icorr*Icorr2) > 0)
                 ccorr[w] *= self.maskcorrs[i][w]/Icorr[w]/Icorr2[w]
 
             if 'regular' in normalization:
+                # only run on overlapping regions for correlation
+                w = self.pxlst_maskcorrs[i]
                 ccorr[w] /= self.maskcorrs[i][w] * \
                             np.average(self.tmpimgs[i].
                                        ravel()[self.subpxlsts[i]])**2

--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -880,8 +880,6 @@ class CrossCorrelator:
 
     '''
     # TODO : when mask is None, don't compute a mask, submasks
-    # TODO : do for 2 images
-    # TODO : allow for a wrap around (such as angular correlation)
     def __init__(self, shape, mask=None, normalization=None, axes=None,
                  wrap=False):
         '''

--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -860,6 +860,14 @@ class CrossCorrelator:
         or a list of non-negative integer id's to compute cross-correlations
         separately on.
 
+        The symmetric averaging scheme introduced here is inspired by a paper
+        from Schätzel, although the implementation is novel in that it allows
+        for the usage of arbitrary masks. Reference to Schatzel's original
+        paper is here:
+            Schätzel, Klaus, Martin Drewel, and Sven Stimac. “Photon
+            correlation measurements at large lag times: improving statistical
+            accuracy.” Journal of Modern Optics 35.4 (1988): 711-718.
+
         Examples
         --------
         >> ccorr = CrossCorrelator(mask.shape, mask=mask)
@@ -867,32 +875,45 @@ class CrossCorrelator:
         >> cimg = cc(img)
         or, mask may m
         >> cc = CrossCorrelator(ids)
-            (where ids is same shape as img)
-            cc1 = cc(img)
+        #(where ids is same shape as img)
+        >> cc1 = cc(img)
 
     '''
     # TODO : when mask is None, don't compute a mask, submasks
-    def __init__(self, shape, mask=None, normalization='regular', axes=None):
+    # TODO : do for 2 images
+    # TODO : allow for a wrap around (such as angular correlation)
+    def __init__(self, shape, mask=None, normalization=None, axes=None,
+                 wrap=False):
         '''
             Prepare the spatial correlator for various regions specified by the
             id's in the image.
 
             Parameters
             ----------
+            shape : 1 or 2-tuple
+                The shape of the incoming images or curves. May specify 1D or
+                2D shapes by inputting a 1 or 2-tuple
 
-            mask : an array of integers. Each non-zero integer represents a
-            unique bin. Zero integers are assumed to be ignored regions.
-                if None, creates a mask with all points set to 1
-            normalization:
-                'regular' : divide by pixel number
-                'symavg' : use symmetric averaging or not (can be overridden by
-                    calling routine)
+            mask : 1D or 2D np.ndarray of int, optional
+                Each non-zero integer represents unique bin. Zero integers are
+                assumed to be ignored regions. If None, creates a mask with
+                all points set to 1
 
-            axes : the axes to perform the fft on can either be a 2tuple or 1
-                number.  The former computes a 2D correlation and latter 1D
-                correlation.
+            normalization: string or list of strings, optional
+                These specify the normalization and may be any of the
+                following:
+                    'regular' : divide by pixel number
+                    'symavg' : use symmetric averaging
+                Defaults to ['regular'] normalization
+
+            axes : 1 or 2-tuple
+                the axes to perform the fft on The former computes a 2D
                 (defaults to (-2, -1) if None)
 
+            wrap : bool, optional
+                If False, assume dimensions don't wrap around. If True
+                    assume they do. The latter is useful for circular
+                    dimensions such as angle.
         '''
         if axes is None:
             if len(shape) == 2:
@@ -901,10 +922,11 @@ class CrossCorrelator:
                 axes = (-1,)
 
         if normalization is None:
-            normalization = ['symavg', 'regular']
-        elif type(normalization) is not list:
+            normalization = ['regular']
+        elif not isinstance(normalization, list):
             normalization = list([normalization])
 
+        self.wrap = wrap
         self.axes = axes
         self.normalization = normalization
 
@@ -915,15 +937,17 @@ class CrossCorrelator:
         self.mask = mask
         # initialize all the masks for the correlation
 
-        # not really clean, but making a list of arrays holding the masks
-        # for each id. Ideally, mask is binary so this is one element
-        # to quickly index original images
+        # Making a list of arrays holding the masks for each id. Ideally, mask
+        # is binary so this is one element to quickly index original images
         self.pxlsts = list()
         self.submasks = list()
         # to quickly index the sub images
         self.subpxlsts = list()
         # the temporary images (double the size for the cross correlation)
         self.tmpimgs = list()
+        self.tmpimgs2 = list()
+        self.centers = list()
+
         self.ids = np.sort(np.unique(mask))
         # remove the zero since we ignore, but only if it is there (sometimes
         # may not be)
@@ -943,54 +967,94 @@ class CrossCorrelator:
 
             # this could be replaced by skimage cropping and padding
             submasktmp = _crop_from_mask(masktmp)
-            submask = _expand_image(submasktmp)
+
+            if self.wrap is False:
+                submask = _expand_image(submasktmp)
 
             tmpimg = np.zeros_like(submask)
 
             self.submasks.append(submask)
             self.subpxlsts.append(np.where(submask.ravel() == 1)[0])
             self.tmpimgs.append(tmpimg)
+            # make sure it's a copy and not a ref
+            self.tmpimgs2.append(tmpimg.copy())
             maskcorr = _cross_corr(submask)
             # quick fix for finite numbers should be integer so
             # choose some small value to threshold
             maskcorr *= maskcorr > .5
             self.maskcorrs.append(maskcorr)
             self.pxlst_maskcorrs.append(maskcorr > 0)
+            # centers are shape//2 as performed by fftshift
+            self.centers.append(np.array(maskcorr.shape)//2)
 
-    def __call__(self, img1, img2=None, normalization=None, PF=False,
-                 return_indices=False):
-        ''' Run the analysis on an image, or two
+    def __call__(self, img1, img2=None, normalization=None):
+        ''' Run the cross correlation on an image/curve or against two
+                images/curves
 
-        TODO : do for two images
+            Parameters
+            ----------
+            img1 : 1D or 2D np.ndarray
+                The image (or curve) to run the cross correlation on
+
+            img2 : 1D or 2D np.ndarray
+                If not set to None, run cross correlation of this image (or
+                curve) against img1. Default is None.
+
+            normalization : string or list of strings
+                normalization types. If not set, use internally saved
+                normalization parameters
+
+            Returns
+            -------
+            ccorrs : 1d or 2d np.ndarray
+                An image of the correlation. The zero correlation is
+                located at shape//2 where shape is the 1 or 2-tuple
+                shape of the array
+
         '''
         if normalization is None:
             normalization = self.normalization
 
-        # right now doesn't work , ened to add tmpimgs2
         if img2 is None:
+            self_correlation = True
             img2 = img1
+        else:
+            self_correlation = False
 
         ccorrs = list()
-        if PF:
-            rngiter = tqdm(range(self.nids))
-        else:
-            rngiter = range(self.nids)
+        rngiter = tqdm(range(self.nids))
 
         for i in rngiter:
             self.tmpimgs[i] *= 0
             self.tmpimgs[i].ravel()[
                                     self.subpxlsts[i]
                                     ] = img1.ravel()[self.pxlsts[i]]
-            # also multiply by maskcorrs > 0 to ignore invalid regions
-            ccorr = _cross_corr(self.tmpimgs[i])*(self.maskcorrs[i] > 0)
+            if not self_correlation:
+                self.tmpimgs2[i] *= 0
+                self.tmpimgs2[i].ravel()[
+                                        self.subpxlsts[i]
+                                        ] = img2.ravel()[self.pxlsts[i]]
 
+            # multiply by maskcorrs > 0 to ignore invalid regions
+            if self_correlation:
+                ccorr = _cross_corr(self.tmpimgs[i])*(self.maskcorrs[i] > 0)
+            else:
+                ccorr = _cross_corr(self.tmpimgs[i], self.tmpimgs2[i]) * \
+                        (self.maskcorrs[i] > 0)
+            # only select valid regions
             w = self.pxlst_maskcorrs[i]
+
+            # now handle the normalizations
             if 'symavg' in normalization:
                 # do symmetric averaging
                 Icorr = _cross_corr(self.tmpimgs[i] *
                                     self.submasks[i], self.submasks[i])
-                Icorr2 = _cross_corr(self.submasks[i], self.tmpimgs[i] *
-                                     self.submasks[i])
+                if self_correlation:
+                    Icorr2 = _cross_corr(self.submasks[i], self.tmpimgs[i] *
+                                         self.submasks[i])
+                else:
+                    Icorr2 = _cross_corr(self.submasks[i], self.tmpimgs2[i] *
+                                         self.submasks[i])
                 ccorr[w] *= self.maskcorrs[i][w]/Icorr[w]/Icorr2[w]
 
             if 'regular' in normalization:
@@ -1007,17 +1071,21 @@ class CrossCorrelator:
 
 
 def _cross_corr(img1, img2=None, axes=None):
-    '''Compute the cross correlation of two images.
-        Right now does not take mask into account.
-        todo: take mask into account (requires extra calculations)
-        note : changed to iFFT(FFT(img1)^* x FFT(img2))
-            so that a shift right means that image 2 is to the right of image 1
-            old calcluation was iFFT(FFT(img1) x FFT(img2)^*)  (note change of
-            order of conjugate)
+    ''' Compute the cross correlation of one (or two) images.
 
-        wrap : if False, double the array before convolution (to avoid wrap
-            around) if True, do nothing to image
-            If wrap is true, it also returns a mask
+        Parameters
+        ----------
+        img1 : 1d or 2d np.ndarray
+            the image or curve to cross correlate
+
+        img2 : 1d or 2d np.ndarray, optional
+            If set, cross correlate img1 against img2.  A shift of img2
+            to the right of img1 will lead to a shift of the point of
+            highest correlation to the right.
+            Default is set to None
+
+        axes : 1 or 2-tuple
+            the axis or axes to perform the cross correlation on
     '''
     if axes is None:
         if img1.ndim == 2:
@@ -1028,8 +1096,8 @@ def _cross_corr(img1, img2=None, axes=None):
     if img2 is None:
         img2 = img1
 
-    imgc = fftshift(ifft2(np.conj(fft2(img1, axes=axes)) *
-                    fft2(img2, axes=axes), axes=axes).real)
+    imgc = fftshift(ifft2(fft2(img1, axes=axes) *
+                    np.conj(fft2(img2, axes=axes)), axes=axes).real)
 
     return imgc
 
@@ -1039,8 +1107,17 @@ def _crop_from_mask(mask):
         Crop an image from a given mask
         returns the sub-selected pixels, as well as the new masked image
 
-        works for a 2D or 1D case
+        Parameters
+        ----------
+        mask : 1d or 2d np.ndarray
+            The data to be cropped. This consists of integers >=0.
+            Regions with 0 are masked and regions > 1 are kept.
 
+       Returns
+       -------
+       mask : 1d or 2d np.ndarray
+           The cropped image. This image is cropped as much as possible
+           without losing unmasked data.
     '''
     dims = mask.shape
     pxlst = np.where(mask.ravel() != 0)[0]
@@ -1061,6 +1138,7 @@ def _crop_from_mask(mask):
 
     oldimg = np.zeros(dims)
     oldimg.ravel()[pxlst] = 1
+
     if len(dims) > 1:
         mask = np.copy(oldimg[minpixelx:maxpixelx+1, minpixely:maxpixely+1])
     else:
@@ -1070,9 +1148,18 @@ def _crop_from_mask(mask):
 
 
 def _expand_image(img):
-    ''' make an image with twice the size, plus one.
+    ''' Convenience routine to make an image with twice the size, plus
+            one.
 
-        works with 1D samples as well
+        Parameters
+        ----------
+        img : 1d or 2d np.ndarray
+            The image (or curve) to expand
+
+        Returns
+        -------
+        img : 1d or 2d np.ndarray
+            The expanded image
     '''
     imgold = img
     dims = imgold.shape

--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -861,15 +861,12 @@ class CrossCorrelator:
         separately on.
 
         The symmetric averaging scheme introduced here is inspired by a paper
-        from Schätzel, although the implementation is novel in that it allows
-        for the usage of arbitrary masks. Reference to Schatzel's original
-        paper is here:
-            Schätzel, Klaus, Martin Drewel, and Sven Stimac. “Photon
-            correlation measurements at large lag times: improving statistical
-            accuracy.” Journal of Modern Optics 35.4 (1988): 711-718.
+        from Schätzel [1], although the implementation is novel in that it
+        allows for the usage of arbitrary masks.
 
         Examples
         --------
+
         >> ccorr = CrossCorrelator(mask.shape, mask=mask)
         >> # correlated image
         >> cimg = cc(img)
@@ -877,6 +874,14 @@ class CrossCorrelator:
         >> cc = CrossCorrelator(ids)
         #(where ids is same shape as img)
         >> cc1 = cc(img)
+
+        References
+        ----------
+        .. [1] Schätzel, Klaus, Martin Drewel, and Sven Stimac. “Photon
+               correlation measurements at large lag times: improving
+               statistical accuracy.” Journal of Modern Optics 35.4 (1988):
+               711-718.
+
 
     '''
     # TODO : when mask is None, don't compute a mask, submasks


### PR DESCRIPTION
Here is an initial pass and suggested API of the mask aware spatial correlations. I tried to remake the API into something more user friendly/scalable. The name is `CrossCorrelator` since it is not necessarily restricted to the spatial domain.

Idea is (`img` and `mask` can be a 1D curve):
```python
    ccorr = CrossCorrelator(mask.shape, mask=mask, method='symavg')
    cimg = ccorr(img)
```
See [pdf](https://github.com/ordirules/notebooks/blob/master/CrossCorrelator.pdf), or alternatively, the [notebook](https://github.com/ordirules/notebooks/blob/master/CrossCorrelator.ipynb) (equations don't show up well for the latter).

Some things to consider:
1. Is `correlation.py` the appropriate place for this code? It's not an accumulator as well, but perhaps should it become one?
2. The routines `_cross_corr`, `_crop_from_mask` and `_expand_image` may likely be replaced by scikit-image routines (or similar). I would like to eventually search but I thought I would start submitting this for open discussion.
3. There will likely be different averaging options. The `method` option accepts either one option, or a list of options. (ex: method =['symavg', 'maxnorm'] etc, where `maxnorm` is currently made up)

@yugangzhang, @danielballan, @tacaswell , @chrisvam, @CJ-Wright please add anyone you think may be able to weigh in on this, we should be extremely critical for the first pass.

Adding in tests is a matter of translating the notebook into a test.

Thanks!