### PR TITLE
Add rpix

### DIFF
--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -170,7 +170,7 @@ class BinnedStatisticDD(object):
 
         for i in np.arange(self.D):
             # Rounding precision
-            decimal = int(-np.log10(dedges[i].min())) + 6
+            decimal = int(-np.log10(np.maximum(1e-6, dedges[i].min()))) + 6
             # Find which points are on the rightmost edge.
             on_edge = np.where(np.around(sample[:, i], decimal) ==
                                np.around(self.edges[i][-1], decimal))[0]

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -569,8 +569,8 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
         if origin is None:
             origin = (shape[0] - 1) / 2., (shape[1] - 1) / 2.
 
-        rpix = radial_grid(origin, shape)
-        phipix = angle_grid(origin, shape)
+        r_map = radial_grid(origin, shape)
+        phi_map = angle_grid(origin, shape)
 
         self.expected_shape = tuple(shape)
         if mask is not None:
@@ -580,8 +580,8 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
                                  ' Received: ' + str(mask.shape))
             mask = mask.reshape(-1)
 
-        super(RPhiBinnedStatistic, self).__init__(rpix.reshape(-1),
-                                                  phipix.reshape(-1),
+        super(RPhiBinnedStatistic, self).__init__(r_map.reshape(-1),
+                                                  phi_map.reshape(-1),
                                                   statistic,
                                                   bins=bins,
                                                   mask=mask,
@@ -635,7 +635,7 @@ class RadialBinnedStatistic(BinnedStatistic1D):
     """
 
     def __init__(self, shape, bins=10, range=None, origin=None, mask=None,
-                 rpix=None, statistic='mean'):
+                 r_map=None, statistic='mean'):
         """
         Parameters:
         -----------
@@ -685,8 +685,8 @@ class RadialBinnedStatistic(BinnedStatistic1D):
         if origin is None:
             origin = (shape[0] - 1) / 2, (shape[1] - 1) / 2
 
-        if rpix is None:
-            rpix = radial_grid(origin, shape)
+        if r_map is None:
+            r_map = radial_grid(origin, shape)
 
         self.expected_shape = tuple(shape)
         if mask is not None:
@@ -696,7 +696,7 @@ class RadialBinnedStatistic(BinnedStatistic1D):
                                  ' Received: ' + str(mask.shape))
             mask = mask.reshape(-1)
 
-        super(RadialBinnedStatistic, self).__init__(rpix.reshape(-1),
+        super(RadialBinnedStatistic, self).__init__(r_map.reshape(-1),
                                                     statistic,
                                                     bins=bins,
                                                     mask=mask,

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -635,7 +635,7 @@ class RadialBinnedStatistic(BinnedStatistic1D):
     """
 
     def __init__(self, shape, bins=10, range=None, origin=None, mask=None,
-            rpix=None, statistic='mean'):
+                 rpix=None, statistic='mean'):
         """
         Parameters:
         -----------

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -170,7 +170,7 @@ class BinnedStatisticDD(object):
 
         for i in np.arange(self.D):
             # Rounding precision
-            decimal = int(-np.log10(np.maximum(1e-6, dedges[i].min()))) + 6
+            decimal = int(-np.log10(dedges[i].min())) + 6
             # Find which points are on the rightmost edge.
             on_edge = np.where(np.around(sample[:, i], decimal) ==
                                np.around(self.edges[i][-1], decimal))[0]

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -634,8 +634,8 @@ class RadialBinnedStatistic(BinnedStatistic1D):
     image in radius.
     """
 
-    def __init__(self, shape, bins=10, range=None,
-                 origin=None, mask=None, statistic='mean'):
+    def __init__(self, shape, bins=10, range=None, origin=None, mask=None,
+            rpix=None, statistic='mean'):
         """
         Parameters:
         -----------
@@ -661,6 +661,9 @@ class RadialBinnedStatistic(BinnedStatistic1D):
         mask : 2-dimensional np.ndarray of ints, optional
             array of zero/non-zero values, with shape `shape`.
             zero values will be ignored.
+        r_map : the map of pixel radii for each pixel. This is useful when the
+            detector has some curvature or is a more complex 2D shape embedded
+            in a 3D space (for example, Ewald curvature).
         statistic : string or callable, optional
             The statistic to compute (default is 'mean').
             The following statistics are available:
@@ -682,7 +685,8 @@ class RadialBinnedStatistic(BinnedStatistic1D):
         if origin is None:
             origin = (shape[0] - 1) / 2, (shape[1] - 1) / 2
 
-        rpix = radial_grid(origin, shape)
+        if rpix is None:
+            rpix = radial_grid(origin, shape)
 
         self.expected_shape = tuple(shape)
         if mask is not None:

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -83,11 +83,13 @@ class TestRadialBinnedStatistic(object):
                 else:
                     radbinstat = RadialBinnedStatistic(shape, bins,
                                                        statistic=stat,
-                                                       mask=mask, rpix=self.rgrid,
+                                                       mask=mask,
+                                                       rpix=self.rgrid,
                                                        **kwargs)
                     radbinstat_f = RadialBinnedStatistic(shape, bins,
                                                          statistic=stat_func,
-                                                         mask=mask, rpix=self.rgrid,
+                                                         mask=mask,
+                                                         rpix=self.rgrid,
                                                          **kwargs)
                 binned = radbinstat(self.image)
                 binned_f = radbinstat_f(self.image)
@@ -190,9 +192,6 @@ class TestRadialBinnedStatistic(object):
 
     def testRadialBinnedStatistic_rpix(self):
         self._testRadialBinnedStatistic(rfac=1.1)
-
-def test_RadialBinnedStatistic_rpix():
-    ''' same test but where rpix is supplied.'''
 
 
 def test_BinnedStatistics1D():

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -84,12 +84,12 @@ class TestRadialBinnedStatistic(object):
                     radbinstat = RadialBinnedStatistic(shape, bins,
                                                        statistic=stat,
                                                        mask=mask,
-                                                       rpix=self.rgrid,
+                                                       r_map=self.rgrid,
                                                        **kwargs)
                     radbinstat_f = RadialBinnedStatistic(shape, bins,
                                                          statistic=stat_func,
                                                          mask=mask,
-                                                         rpix=self.rgrid,
+                                                         r_map=self.rgrid,
                                                          **kwargs)
                 binned = radbinstat(self.image)
                 binned_f = radbinstat_f(self.image)
@@ -190,7 +190,7 @@ class TestRadialBinnedStatistic(object):
     def testRadialBinnedStatistic(self):
         self._testRadialBinnedStatistic()
 
-    def testRadialBinnedStatistic_rpix(self):
+    def testRadialBinnedStatistic_rmap(self):
         self._testRadialBinnedStatistic(rfac=1.1)
 
 

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -26,7 +26,10 @@ class TestRadialBinnedStatistic(object):
         colarr = np.arange(self.colsize)
         self.rowgrid, self.colgrid = np.meshgrid(rowarr, colarr, indexing='ij')
 
-    def testRadialBinnedStatistic(self):
+    def _testRadialBinnedStatistic(self, rfac=None):
+        ''' rfac : make the rgrid non-linear and supply to
+            RadialBinnedStatistic.
+        '''
 
         mykwargs = [{'origin': (0, 0),
                      'range': (10, 90)},
@@ -52,6 +55,9 @@ class TestRadialBinnedStatistic(object):
                 # rows are y, cols are x, as in angle_grid in core.utils
                 self.rgrid = np.sqrt((self.rowgrid-origin[0])**2 +
                                      (self.colgrid-origin[1])**2)
+                if rfac is not None:
+                    self.rgrid = self.rgrid**rfac
+
                 self.phigrid = np.arctan2(self.rowgrid-origin[0],
                                           self.colgrid-origin[1])
 
@@ -65,14 +71,24 @@ class TestRadialBinnedStatistic(object):
                     mask = mask_ones
 
                 # test radial case
-                radbinstat = RadialBinnedStatistic(shape, bins,
-                                                   statistic=stat,
-                                                   mask=mask,
-                                                   **kwargs)
-                radbinstat_f = RadialBinnedStatistic(shape, bins,
-                                                     statistic=stat_func,
-                                                     mask=mask,
-                                                     **kwargs)
+                if rfac is None:
+                    radbinstat = RadialBinnedStatistic(shape, bins,
+                                                       statistic=stat,
+                                                       mask=mask,
+                                                       **kwargs)
+                    radbinstat_f = RadialBinnedStatistic(shape, bins,
+                                                         statistic=stat_func,
+                                                         mask=mask,
+                                                         **kwargs)
+                else:
+                    radbinstat = RadialBinnedStatistic(shape, bins,
+                                                       statistic=stat,
+                                                       mask=mask, rpix=self.rgrid,
+                                                       **kwargs)
+                    radbinstat_f = RadialBinnedStatistic(shape, bins,
+                                                         statistic=stat_func,
+                                                         mask=mask, rpix=self.rgrid,
+                                                         **kwargs)
                 binned = radbinstat(self.image)
                 binned_f = radbinstat_f(self.image)
 
@@ -168,6 +184,15 @@ class TestRadialBinnedStatistic(object):
         with assert_raises(ValueError):
             RadialBinnedStatistic(self.image.shape, 10,
                                   mask=np.array([1, 2, 3, 4]))
+
+    def testRadialBinnedStatistic(self):
+        self._testRadialBinnedStatistic()
+
+    def testRadialBinnedStatistic_rpix(self):
+        self._testRadialBinnedStatistic(rfac=1.1)
+
+def test_RadialBinnedStatistic_rpix():
+    ''' same test but where rpix is supplied.'''
 
 
 def test_BinnedStatistics1D():


### PR DESCRIPTION
I've been back and forth about suggesting this but I think it saves time. Sometimes we want to supply the 2D image of bins rather than let RadialBinnedStatistic compute them.
One could then argue that why not used `BinnedStatistic1D`? There is still a small benefit, where we don't have to keep `ravel()`'ing everything.

What this saves is instead of having to do this:
```python
    rbinstat = BinnedStatistic1D(q_map.reshape(-1), bins=bins, mask=mask.ravel())
    sqy = rbinstat(image.ravel())
```

we can do this:
```python
    rbinstat = RadialBinnedStatistic(shape, mask=mask.ravel(), rpix=q_map)
    sqy = rbinstat(image)
```

(for the scientists here, qmap needs to be computed with Ewald curvature taken into account, so it's not a simple 2D geometric radius)