### PR TITLE
ENH: added binmap to binned_statistic

### DIFF
--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -187,6 +187,30 @@ class BinnedStatisticDD(object):
         self.statistic = statistic
 
     @property
+    def binmap(self):
+        ''' Return the map of the bins per dimension.
+                i.e. reverse transformation of flattened to unflattened bins
+
+            Returns
+            -------
+            D np.ndarrays of length N where D is the number of dimensions
+                and N is the number of data points.
+        '''
+        N, = self.xy.shape
+        binmap = np.zeros((self.D, N))
+        denominator = 1
+
+        for i in range(self.D):
+            ind = self.D - i - 1
+            subbinmap = (self.xy // denominator)
+            if i < self.D - 1:
+                subbinmap = subbinmap % self.nbin[self.ni[ind - 1]]
+            binmap[ind] = subbinmap
+            denominator *= self.nbin[self.ni[ind]]
+
+        return binmap
+
+    @property
     def flatcount(self):
         # Compute flatcount the first time it is accessed. Some statistics
         # never access it.

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -197,7 +197,7 @@ class BinnedStatisticDD(object):
                 and N is the number of data points.
         '''
         N, = self.xy.shape
-        binmap = np.zeros((self.D, N))
+        binmap = np.zeros((self.D, N), dtype=int)
         denominator = 1
 
         for i in range(self.D):

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -235,7 +235,7 @@ def test_binmap():
     img = R*np.cos(5*Phi)
     rs = RPhiBinnedStatistic(img.shape)
 
-    binmap = rs.binmap.reshape((-1, *img.shape))
+    binmap = rs.binmap.reshape((-1, img.shape[0], img.shape[1]))
 
     assert_array_almost_equal(binmap[0][40][::10], np.array([8, 6, 5, 4, 2, 2,
                                                              2, 4, 5, 6]))


### PR DESCRIPTION
Here's something that has been bothering me and @yugangzhang . When binning using `BinnedStatistic`, there is no straightforward reverse transformation from the flattened bin ids back to the bins. Here's a suggested improvement. Add a `binmap` member which computes the reverse transformation.
For example, it allows you to recover the bins from the top two plots in this figure, coming from the `self.xy` member of the bottom plot:


```python
# import numpy and matplotlib etc
from pylab import *
ion()

from skbeam.core.accumulators.binned_statistic import RPhiBinnedStatistic,\
        BinnedStatisticDD
from skbeam.core.utils import radial_grid, angle_grid

shape = np.array([100, 100])

R = radial_grid(shape/2, shape)
Phi = angle_grid(shape/2., shape)

img = R*np.cos(5*Phi)
rs = RPhiBinnedStatistic(img.shape)

res = rs(img)

binmap = rs.binmap.reshape((-1, *img.shape))

figure(2);clf()
subplot(2,2,1)
title("Rs")
imshow(binmap[0])
subplot(2,2,2)
title("Phis")
imshow(binmap[1])
subplot(2,2,3)
title("RPhibins")
imshow(rs.xy.reshape(shape))
```

This leads to the following image:
![Image of bins](http://i.imgur.com/sF91X54.png)
(From [imgur](http://imgur.com/a/McErx))
The top two plots are the r and phi bins, reverse transformed, and the last plot is the flattened bins `self.xy` that `binned_statistic` uses to perform the bin count.

NOTE : This is incomplete. Still need to add tests. I also tested 3D and it also works. I will also take the opportunity to add some general DD tests.