### PR TITLE
ENH: Added r_map option to RPhiBinnedStatistic

### DIFF
--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -546,7 +546,7 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
     """
 
     def __init__(self, shape, bins=10, range=None,
-                 origin=None, mask=None, statistic='mean'):
+                 origin=None, mask=None, r_map=None, statistic='mean'):
         """
         Parameters:
         -----------
@@ -572,6 +572,9 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
         mask : 2-dimensional np.ndarray of ints, optional
             array of zero/non-zero values, with shape `shape`.
             zero values will be ignored.
+        r_map : the map of pixel radii for each pixel. This is useful when the
+            detector has some curvature or is a more complex 2D shape embedded
+            in a 3D space (for example, Ewald curvature).
         statistic : string or callable, optional
             The statistic to compute (default is 'mean').
             The following statistics are available:
@@ -593,7 +596,9 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
         if origin is None:
             origin = (shape[0] - 1) / 2., (shape[1] - 1) / 2.
 
-        r_map = radial_grid(origin, shape)
+        if r_map is None:
+            r_map = radial_grid(origin, shape)
+
         phi_map = angle_grid(origin, shape)
 
         self.expected_shape = tuple(shape)

--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -572,9 +572,10 @@ class RPhiBinnedStatistic(BinnedStatistic2D):
         mask : 2-dimensional np.ndarray of ints, optional
             array of zero/non-zero values, with shape `shape`.
             zero values will be ignored.
-        r_map : the map of pixel radii for each pixel. This is useful when the
-            detector has some curvature or is a more complex 2D shape embedded
-            in a 3D space (for example, Ewald curvature).
+        r_map : 2d np.ndarray of floats, optional
+            The map of pixel radii for each pixel. For example, r_map can be
+            used to define the radius of each pixel relative to the origin in
+            reciprocal space (on the Ewald sphere).
         statistic : string or callable, optional
             The statistic to compute (default is 'mean').
             The following statistics are available:

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -6,7 +6,7 @@ from nose.tools import assert_raises
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 import numpy as np
 import scipy.stats
-from ...utils import bin_edges_to_centers
+from skbeam.core.utils import bin_edges_to_centers
 from skbeam.core.utils import radial_grid, angle_grid
 
 stats_list = [('mean', np.mean), ('median', np.median), ('count', len),


### PR DESCRIPTION
Same idea as #508 .
This is not ready yet. Will be a good opportunity to finally add tests to `RPhiBinnedStatistic`...

Only `r_map` can be overridden but not `phi_map`. We could add it, but I anticipate this to be only useful for the cases of Ewald curvature on 2D data sets.