### PR TITLE
ENH: updated package setup information

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include versioneer.py
 include skbeam/_version.py
 include requirements.txt
 include optional-requirements.txt
+include src/ctrans.h

--- a/setup.py
+++ b/setup.py
@@ -27,15 +27,24 @@ def c_ext():
 
     # compile for MacOS without openmp
     if sys.platform == 'darwin':
-        return [Extension('skbeam.ext.ctrans', ['src/ctrans.c'])]
+        return [Extension('skbeam.ext.ctrans', ['src/ctrans.c'],
+                          include_dirs=['src'])]
     # compile the extension on Linux.
     return [Extension('skbeam.ext.ctrans', ['src/ctrans.c'],
+                      include_dirs=['src'],
                       extra_compile_args=['-fopenmp'],
                       extra_link_args=['-lgomp'])]
 
 
+# add all cython extensions here
 def cython_ext():
-    return cythonize("**/*.pyx")
+    try:
+        ext = cythonize("skbeam/core/accumulators/histogram.pyx")
+    except ValueError:
+        # likely the file is already compiled
+        ext = [Extension("skbeam.core.accumulators.histogram",
+                         ["skbeam/core/accumulators/histogram.c"])]
+    return ext
 
 
 setup(


### PR DESCRIPTION
@mrakitin and I had packaging issues. As of now, the linux version of scikit-beam on [https://pypi.python.org/pypi/scikit-beam/0.0.12](pypi) does not install (running `pip install scikit-beam`).


Problem arises from creating the `.tar.gz` file which does not pass on important files for setup. Fixed two issues:
1. Check if `histogram.pyx` has been cythonized (translated to c code). If yes, tell distutils to compile the c code directly and avoid the cythonize step.
2. Make sure that the `ctrans.c` c code has its header `ctrans.h` sent.

In the process, we have removed wildcards and made declarations more explicit. If we are to add any extra cython code, we must declare it in the `setup.py` file.

Note that there is likely a simple permutation. This is a working version.

@danielballan can you test this with Mac?
To test, run `python setup.py sdist`
Then go in `dist/...` and `pip install` the wheel there (I think)