### PR TITLE
WIP: Flatten Correlation

### DIFF
--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,5 +1,4 @@
 lmfit==0.8.1
 scipy
 scikit-image
-xraylib
 netCDF4

--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -921,11 +921,14 @@ class CrossCorrelator:
             mask = np.ones(shape)
 
         self.shape = shape
-        # for 1d quick indexing
-        width = shape[0]
         self.ndim = len(shape)
         if self.ndim == 1:
             mask = mask.reshape((1, shape[0]))
+            # for 1d quick indexing
+            width = shape[0]
+        elif self.ndim == 2:
+            width = shape[1]
+
 
         if self.ndim > 2:
             raise ValueError("Dimensions other than 1 or 2 not supported")
@@ -986,8 +989,12 @@ class CrossCorrelator:
             # row*width + col
             row = ppii[index_start:index_stop]//width
             ppii[index_start:index_stop] -= extents[i, 0]*width + extents[i, 2]
-            # also subtract leftover elements from row
-            ppii[index_start:index_stop] -= extents[i, 2]*(row-extents[i,0])
+            new_width = extents[i, 3] - extents[i, 2] + 1
+            # the subregion has a new width
+            old_rows = ppii[index_start:index_stop] // width
+            old_cols = ppii[index_start:index_stop] % width
+            ppii[index_start:index_stop] = old_rows*new_width + old_cols
+
             #ppii[index_start:index_stop]%width -= shapes[i, 0]
             #ppjj[index_start:index_stop] -= shapes[i, 2]
         # now save to object
@@ -1097,8 +1104,12 @@ class CrossCorrelator:
         ccorrs = list()
         rngiter = tqdm(range(self.nids))
 
-        # for 1d indexing
-        width = self.shape[0]
+        if self.ndim == 1:
+            # for 1d quick indexing
+            width = self.shape[0]
+        elif self.ndim == 2:
+            width = self.shape[1]
+
 
         idpos = self.idpos
         for i in rngiter:


### PR DESCRIPTION
EDIT to elaborate more on this. I changed how the indexing is done in CrossCorrelator to be dask friendly. There should be no API change here.

Dask doesn't support fancy indexing yet:
```py
import numpy as np
import dask.array as da
arr= da.from_array(np.ones((10,10)), chunks=10)

In [29]: arr[[1,2], [1,2]]
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
NotImplementedError: Don't yet support nd fancy indexing
```
but flattening will work:
```py
In [30]: arr.ravel()[[1*10+1, 2*10+2]]
Out[30]: dask.array<getitem, shape=(2,), dtype=float64, chunksize=(2,)>
```

I think it might be good to work in terms of flattened arrays for now. So far works for me but I need to test further. This PR serves as a place holder. Do not merge.