### PR TITLE
Improve binmap doc

### DIFF
--- a/skbeam/core/accumulators/binned_statistic.py
+++ b/skbeam/core/accumulators/binned_statistic.py
@@ -196,6 +196,9 @@ class BinnedStatisticDD(object):
             -------
             D np.ndarrays of length N where D is the number of dimensions
                 and N is the number of data points.
+                For each dimension, the min bin id is 0 and max n+1 where n is
+                the number of bins in that dimension. The ids 0 and n+1 mark
+                the outliers of the bins.
         '''
         N, = self.xy.shape
         binmap = np.zeros((self.D, N), dtype=int)


### PR DESCRIPTION
quickly explain what `binmap` is a little more to avoid confusion

@CJ-Wright 


(question arose for how to refill a new image with the statistic obtained in binstat.
We may also want to perhaps document `xy`?
```py
from skbeam.core.accumulators.binned_statistic import RPhiBinnedStatistic
import numpy as np
img = np.random.random((100,100))
nbins = 20
rbinstat = RadialBinnedStatistic(img.shape, origin=(50,50), bins=nbins,
                                  range=((1, 9)))#, (0, np.pi)))
res = rbinstat(img, statistic='mean')
# re-interpolate into an image
new_img = np.zeros_like(img)
# only choose bins that are not outliers
# so ignore xy==0 and xy == nbins+1
xy = rbinstat.xy
w, = np.where((xy > 0)*(xy < nbins+1))
# now get new xy
new_xy = xy.ravel()[w]
# subtract 1 so that it's zero based
new_xy -= 1
new_img.ravel()[w] = res[new_xy]

```
)