### PR TITLE
Add LICENSE to manifest file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include versioneer.py
 include skbeam/_version.py
 include requirements.txt
 include optional-requirements.txt
+include LICENSE


### PR DESCRIPTION
This is required for conda-forge / conda-build to pick up the license file properly