### PR TITLE
Compatibility with lmfit 0.9.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ matrix:
     python: 3.6
 
 python:
-  - 2.7
   - 3.6
 
 env:

--- a/skbeam/core/fitting/xrf_model.py
+++ b/skbeam/core/fitting/xrf_model.py
@@ -256,6 +256,7 @@ def _copy_model_param_hints(target, source, params):
                               value=source[label].value,
                               expr=None)  # Originally was expr=label
 
+
 def _copy_model_param_hints_EXPR(target, source, params):
     """
     Copy parameters (set hints) from one model to another

--- a/skbeam/core/fitting/xrf_model.py
+++ b/skbeam/core/fitting/xrf_model.py
@@ -220,7 +220,8 @@ def _copy_model_param_hints(target, source, params):
         target.set_param_hint(label,
                               value=source[label].value,
                               expr=label)
-
+                              # expr=None)
+                              # expr = '')
 
 def update_parameter_dict(param, fit_results):
     """

--- a/skbeam/core/fitting/xrf_model.py
+++ b/skbeam/core/fitting/xrf_model.py
@@ -219,9 +219,17 @@ def _copy_model_param_hints(target, source, params):
     for label in params:
         target.set_param_hint(label,
                               value=source[label].value,
-                              expr=label)
-                              # expr=None)
-                              # expr = '')
+                              expr=None)
+
+def _copy_model_param_hints_EXPR(target, source, params):
+
+    for label in params:
+        value = source[label].value
+        for hint_name, hint_values in target.param_hints.items():
+            if label in hint_name and label != hint_name and 'compton' not in hint_name:
+                hint_values[label] = value
+                hint_values['expr'] =  label
+
 
 def update_parameter_dict(param, fit_results):
     """
@@ -951,6 +959,12 @@ class ModelSpectrum(object):
 
         for element in self.elemental_lines:
             self.mod += self.setup_element_model(element)
+
+        # This is just a copy of the parameter list. Multiple occurrances.
+        param_hints_to_copy = ['e_offset', 'e_linear', 'e_quadratic',
+                               'fwhm_offset', 'fwhm_fanoprime']
+        _copy_model_param_hints_EXPR(self.mod, self.compton_param,
+                                param_hints_to_copy)
 
     def model_fit(self, channel_number, spectrum, weights=None,
                   method='leastsq', **kwargs):

--- a/skbeam/core/fitting/xrf_model.py
+++ b/skbeam/core/fitting/xrf_model.py
@@ -273,7 +273,6 @@ def _copy_model_param_hints_EXPR(target, source, params):
         The model to be updated
     source : lmfit.Model
         The model to copy from
-
     params : list
        The names of the parameters to copy
 


### PR DESCRIPTION
Fix: compatibility with ```lmfit 0.9.13``` (latest version). Non-invasive fix that bypasses evaluation of 'expr' attribute (string that contains expression specifying restrictions on the parameter, which is evaluated by asteval module) of parameters during Model.make_params() function of ```lmfit 0.9.13```. ```lmfit 0.8.3``` does not perform evaluation of 'expr' attributes until ```Model.fit()``` function is called.