### PR TITLE
Find center of rings using Hough Transform 

### DIFF
--- a/skbeam/core/roi.py
+++ b/skbeam/core/roi.py
@@ -43,11 +43,13 @@ from __future__ import absolute_import, division, print_function
 import collections
 import scipy.ndimage.measurements as ndim
 from skimage.draw import line
-from skimage import img_as_float, feature, color, draw
+from skimage import img_as_float, feature, color, draw, transfrom
 from skimage.measure import ransac, CircleModel
 import numpy as np
 from . import utils
 import logging
+import matplotlib.pyplot as plot
+
 
 logger = logging.getLogger(__name__)
 
@@ -757,3 +759,65 @@ def auto_find_center_rings(avg_img, sigma=1, no_rings=4, min_samples=3,
         edge_pts_xy = edge_pts_xy[~inliers]
 
     return center, image, radii
+
+def find_center_rings_hough(image, num_rings, rad_range, intensity_thresh, sigma, v_range = None):
+    """
+    Take angled cut or multiple incremented cuts of a image data.
+
+    Parameters
+    ----------
+    image : ndarray
+        Image data
+    num_rings : int
+        Number of candidate circles to be searched for
+    rad_range : array
+        The min, max, and increment for range of candidate radii to be searched
+    intensity_thresh : array
+        Min and max of intensity to be used in canny filter
+    sigma : float
+        Standard deviation applied in canny filter
+    v_range : array
+        Min and max for matplotlib colormap
+
+    Returns
+    -------
+    center_pt : array
+        Average center of the candidate circles
+    radii: array
+        radii of the candidate circles
+
+    """
+
+    low_thresh = intensity_thresh[0]
+    hi_thresh = intensity_thresh[1]
+    sigma = sigma
+    edges = feature.canny(image, sigma, low_threshold= low_thresh, high_threshold= hi_thresh)
+
+    low = rad_range[0]
+    hi = rad_range[1]
+    step = rad_range[2]
+
+    # Range of possible radii
+    hough_radii = np.arange(low, hi, step)
+    hough_res = transform.hough_circle(edges, hough_radii)
+
+    # Selects the most prominent circles, up to num_rings
+    accums, cx, cy, radii = transform.hough_circle_peaks(hough_res, hough_radii,
+                                               total_num_peaks=num_rings)
+
+    # Draw them
+    fig, ax = plt.subplots(ncols=1, nrows=1, figsize=(10, 4))
+    Z = color.gray2rgb(image)
+    for center_y, center_x, radius in zip(cy, cx, radii):
+        circy, circx = draw.circle_perimeter(center_y, center_x, radius,
+                                        shape=Z.shape)
+        ax.scatter(x = circx,y =circy, s = 1, c = 'red')
+    center_pt = [np.average(cx), np.average(cy)]
+
+    ax.scatter(center_pt[0], center_pt[1], s =20, c = 'red')
+    if v_range != None:
+        ax.imshow(image, cmap="viridis", vmin = v_range[0], vmax = v_range[1])
+    else:
+        ax.imshow(image, cmap="viridis")
+    plt.show()
+    return center_pt,radii

--- a/skbeam/core/utils.py
+++ b/skbeam/core/utils.py
@@ -1300,9 +1300,9 @@ def bin_grid(image, r_array, pixel_sizes, statistic='mean', mask=None,
 
         Returns
         -------
-        data : tuple
-            For each line cut made, returns the angle of the cut, an array of the intensity values sampled
-            and an array of the corresponding radii relative to center at each data point along the
+        data : list
+            A list of tuples that contains data from each cut. Each tuple contains the angle of the cut taken, an array of the intensity values sampled along the line cut
+            and an array of the corresponding radii relative to center at each point sampled along the
             line cut.
 
         """
@@ -1313,7 +1313,7 @@ def bin_grid(image, r_array, pixel_sizes, statistic='mean', mask=None,
         if mute_graph == False:
             fig, axes = plt.subplots(nrows=2, figsize = (10,10))
             axes[0].scatter(center_x, center_y, s= 50, c='red')
-            
+
         curr = angle
         data = []
 

--- a/skbeam/core/utils.py
+++ b/skbeam/core/utils.py
@@ -68,6 +68,7 @@ class NotInstalledError(ImportError):
     '''
     Custom exception that should be subclassed to handle
     specific missing libraries
+
     '''
     pass
 
@@ -75,9 +76,11 @@ class NotInstalledError(ImportError):
 class MD_dict(MutableMapping):
     """
     A class to make dealing with the meta-data scheme for DataExchange easier
+
     Examples
     --------
     Getting and setting data by path is possible
+
     >>> tt = MD_dict()
     >>> tt['name'] = 'test'
     >>> tt['nested.a'] = 2
@@ -214,12 +217,15 @@ class verbosedict(dict):
 
 class RCParamDict(MutableMapping):
     """A class to make dealing with storing default values easier.
+
     RC params is a hold- over from the UNIX days where configuration
     files are 'rc' files.  See
     http://en.wikipedia.org/wiki/Configuration_file
+
     Examples
     --------
     Getting and setting data by path is possible
+
     >>> tt = RCParamDict()
     >>> tt['name'] = 'test'
     >>> tt['nested.a'] = 2
@@ -439,25 +445,30 @@ def subtract_reference_images(imgs, is_reference):
     background/dark current/reference images.  The nearest reference
     image in the reverse temporal direction is subtracted from each
     measured image.
+
     Parameters
     ----------
     imgs : numpy.ndarray
         Array of 2-D images
+
     is_reference : 1-D boolean array
         true  : image is reference image
         false : image is measured image
+
     Returns
     -------
     img_corr : numpy.ndarray
         len(img_corr) == len(img_arr) - len(is_reference_img == true)
         img_corr is the array of measured images minus the reference
         images.
+
     Raises
     ------
     ValueError
         Possible causes:
             is_reference contains no true values
             Raised when the first image in the array is not a reference image.
+
     """
     # an array of 1, 0, 1,.. should work too
     if not is_reference[0]:
@@ -485,6 +496,7 @@ def img_to_relative_xyi(img, cx, cy, pixel_size_x=None, pixel_size_y=None):
     Convert the 2D image to a list of x y I coordinates where
     x == x_img - detector_center[0] and
     y == y_img - detector_center[1]
+
     Parameters
     ----------
     img: `ndarray`
@@ -499,6 +511,7 @@ def img_to_relative_xyi(img, cx, cy, pixel_size_x=None, pixel_size_y=None):
         Pixel size in y
     **kwargs: dict
         Bucket for extra parameters in an unpacked dictionary
+
     Returns
     -------
     x : `ndarray`
@@ -537,6 +550,7 @@ def img_to_relative_xyi(img, cx, cy, pixel_size_x=None, pixel_size_y=None):
 def bin_1D(x, y, nx=None, min_x=None, max_x=None):
     """
     Bin the values in y based on their x-coordinates
+
     Parameters
     ----------
     x : array
@@ -549,12 +563,15 @@ def bin_1D(x, y, nx=None, min_x=None, max_x=None):
         Left edge of first bin defaults to minimum value of x
     max_x : float, optional
         Right edge of last bin defaults to maximum value of x
+
     Returns
     -------
     edges : array
         edges of bins, length nx + 1
+
     val : array
         sum of values in each bin, length nx
+
     count : array
         The number of counts in each bin, length nx
     """
@@ -578,6 +595,7 @@ def bin_1D(x, y, nx=None, min_x=None, max_x=None):
 
 def radial_grid(center, shape, pixel_size=None):
     """Convert a cartesian grid (x,y) to the radius relative to some center
+
     Parameters
     ----------
     center : tuple
@@ -591,6 +609,7 @@ def radial_grid(center, shape, pixel_size=None):
         The physical size of the pixels.
         len(pixel_size) should be the same as len(shape)
         defaults to (1,1)
+
     Returns
     -------
     r : array
@@ -609,19 +628,24 @@ def radial_grid(center, shape, pixel_size=None):
 def angle_grid(center, shape, pixel_size=None):
     """
     Make a grid of angular positions.
+
     Read note for our conventions here -- there be dragons!
+
     Parameters
     ----------
     center : tuple
         point in image where r=0; may be a float giving subpixel precision.
         Order is (rr, cc).
+
     shape: tuple
         Image shape which is used to determine the maximum extent of output
         pixel coordinates. Order is (rr, cc).
+
     Returns
     -------
     agrid : array
         angular position (in radians) of each array element in range [-pi, pi]
+
     Note
     ----
     :math:`\\theta`, the counter-clockwise angle from the positive x axis,
@@ -645,12 +669,15 @@ def radius_to_twotheta(dist_sample, radius):
     """
     Converts radius from the calibrated center to scattering angle
     (2:math:`2\\theta`) with known detector to sample distance.
+
     Parameters
     ----------
     dist_sample : float
         distance from the sample to the detector (mm)
+
     radius : array
         The L2 norm of the distance of each pixel from the calibrated center.
+
     Returns
     -------
     two_theta : array
@@ -663,23 +690,30 @@ def wedge_integration(src_data, center, theta_start,
                       delta_theta, r_inner, delta_r):
     """
     Implementation of caking.
+
     Parameters
     ----------
     scr_data : ndarray
         The source-data to be integrated
+
     center : ndarray
         The center of the ring in pixels
+
     theta_start : float
         The angle of the start of the wedge from the
         image y-axis in degrees
+
     delta_theta : float
         The angular width of the wedge in degrees.  Positive
         angles go clockwise, negative go counter-clockwise.
+
     r_inner : float
         The inner radius in pixel units, Must be non-negative
+
     delta_r : float
         The length of the wedge in the radial direction
         in pixel units. Must be non-negative
+
     Returns
     -------
     float
@@ -693,18 +727,23 @@ def bin_edges(range_min=None, range_max=None, nbins=None, step=None):
     Generate bin edges.  The last value in the returned array is
     the right edge of the last bin, the rest of the values are the
     left edges of each bin.
+
     If `range_max` is specified all bin edges will be less than or
     equal to it's value.
+
     If `range_min` is specified all bin edges will be greater than
     or equal to it's value
+
     If `nbins` is specified then there will be than number of bins and
     the returned array will have length `nbins + 1` (as the right most
     edge is included)
+
     If `step` is specified then bin width is approximately `step` (It is
     not exact due to the nature of floats). The arrays generated by
     `np.cumsum(np.ones(nbins) * step)` and `np.arange(nbins) * step` are
     not identical.  This function uses the second method in all cases
     where `step` is specified.
+
     .. warning :: If the set :code:`(range_min, range_max, step)` is
         given there is no guarantee that :code:`range_max - range_min`
         is an integer multiple of :code:`step`.  In this case the left
@@ -714,17 +753,22 @@ def bin_edges(range_min=None, range_max=None, nbins=None, step=None):
         :code:`step` (this is the same behavior as the built-in
         :code:`range()`).  It is not recommended to specify bins in this
         manner.
+
     Parameters
     ----------
     range_min : float, optional
         The minimum value that may be included as a bin edge
+
     range_max : float, optional
         The maximum value that may be included as a bin edge
+
     nbins : int, optional
         The number of bins, if specified the length of the returned
         value will be nbins + 1
+
     step : float, optional
         The step between the bins
+
     Returns
     -------
     edges : np.array
@@ -785,9 +829,11 @@ def grid3d(q, img_stack,
            ymax=None, zmin=None, zmax=None,
            binary_mask=None):
     """Grid irregularly spaced data points onto a regular grid via histogramming
+
     This function will process the set of reciprocal space values (q), the
     image stack (img_stack) and grid the image data based on the bounds
     provided, using defaults if none are provided.
+
     Parameters
     ----------
     q : ndarray
@@ -819,6 +865,7 @@ def grid3d(q, img_stack,
         Binary mask can be two different shapes.
         - 1: 2-D with binary_mask.shape == np.asarray(img_stack[0]).shape
         - 2: 3-D with binary_mask.shape == np.asarray(img_stack).shape
+
     Returns
     -------
     mean : ndarray
@@ -832,6 +879,7 @@ def grid3d(q, img_stack,
     bounds : list
         tuple of (min, max, step) for x, y, z in order: [x_bounds,
         y_bounds, z_bounds]
+
     """
     try:
         from ..ext import ctrans
@@ -927,11 +975,13 @@ def bin_edges_to_centers(input_edges):
     """
     Helper function for turning a array of bin edges into
     an array of bin centers
+
     Parameters
     ----------
     input_edges : array-like
         N + 1 values which are the left edges of N bins
         and the right edge of the last bin
+
     Returns
     -------
     centers : ndarray
@@ -953,17 +1003,24 @@ def q_to_d(q):
     """
     Helper function to convert :math:`d` to :math:`q`.  The point
     of this function is to prevent fat-fingered typos.
+
     By definition the relationship is:
+
     .. math::
+
         q = \\frac{2 \pi}{d}
+
+
     Parameters
     ----------
     q : array
         An array of q values
+
     Returns
     -------
     d : array
        An array of d (plane) spacing in the inverse of the units of ``q``
+
     """
     return (2 * np.pi) / np.asarray(q)
 
@@ -972,17 +1029,24 @@ def d_to_q(d):
     """
     Helper function to convert :math:`d` to :math:`q`.
     The point of this function is to prevent fat-fingered typos.
+
     By definition the relationship is:
+
     .. math::
+
         d = \\frac{2 \pi}{q}
+
     Parameters
     ----------
     d : array
        An array of d (plane) spacing
+
     Returns
     -------
     q : array
         An array of q values in the inverse of the units of ``d``
+
+
     """
     return (2 * np.pi) / np.asarray(d)
 
@@ -990,18 +1054,27 @@ def d_to_q(d):
 def q_to_twotheta(q, wavelength):
     r"""
     Helper function to convert q to two-theta.
+
     By definition the relationship is:
+
     .. math::
+
         \sin\left(\frac{2\theta}{2}\right) = \frac{\lambda q}{4 \pi}
+
     thus
+
     .. math::
+
         2\theta_n = 2 \arcsin\left(\frac{\lambda q}{4 \pi}\right)
+
     Parameters
     ----------
     q : array
         An array of :math:`q` values
+
     wavelength : float
         Wavelength of the incoming x-rays
+
     Returns
     -------
     two_theta : array
@@ -1016,18 +1089,29 @@ def q_to_twotheta(q, wavelength):
 def twotheta_to_q(two_theta, wavelength):
     r"""
     Helper function to convert two-theta to q
+
     By definition the relationship is
+
     .. math::
+
         \sin\left(\frac{2\theta}{2}\right) = \frac{\lambda q}{4 \pi}
+
     thus
+
     .. math::
+
         q = \frac{4 \pi \sin\left(\frac{2\theta}{2}\right)}{\lambda}
+
+
+
     Parameters
     ----------
     two_theta : array
         An array of :math:`2\theta` values
+
     wavelength : float
         Wavelength of the incoming x-rays
+
     Returns
     -------
     q : array
@@ -1044,6 +1128,7 @@ def multi_tau_lags(multitau_levels, multitau_channels):
     """
     Standard multiple-tau algorithm for finding the lag times (delay
     times).
+
     Parameters
     ----------
     multitau_levels : int
@@ -1051,6 +1136,7 @@ def multi_tau_lags(multitau_levels, multitau_channels):
     multitau_channels : int
         number of channels or number of buffers in auto-correlators
         normalizations (must be even)
+
     Returns
     -------
     total_channels : int
@@ -1059,11 +1145,14 @@ def multi_tau_lags(multitau_levels, multitau_channels):
         delay or lag steps for the multiple tau analysis
     dict_lags : dict
         dictionary of delays for each multitau_levels
+
     Notes
     -----
     The multi-tau correlation scheme was used for finding the lag times
     (delay times).
+
     References: text [1]_
+
     .. [1] K. Schätzela, M. Drewela and  S. Stimaca, "Photon correlation
        measurements at large lag times: Improving statistical accuracy,"
        J. Mod. Opt., vol 35, p 711–718, 1988.
@@ -1101,23 +1190,30 @@ def geometric_series(common_ratio, number_of_images, first_term=1):
     ex: number_of_images = 100, first_term =1
     common_ratio = 2, geometric_series =  1, 2, 4, 8, 16, 32, 64
     common_ratio = 3, geometric_series =  1, 3, 9, 27, 81
+
     Parameters
     ----------
     common_ratio : float
         common ratio of the series
+
     number_of_images : int
         number of images
+
     first_term : float, optional
         first term in the series
+
     Return
     ------
     geometric_series : list
         time series
+
     Notes
     -----
     .. math::
         a + ar + ar^2 + ar^3 + ar^4 + ...
+
     a - first term in the series
+
     r - is the common ratio
     """
 
@@ -1132,6 +1228,7 @@ def bin_grid(image, r_array, pixel_sizes, statistic='mean', mask=None,
              bins=None):
     """
     Bin and integrate an image, given the radial array of pixels
+
     Parameters
     ----------
     image: np.array
@@ -1147,16 +1244,19 @@ def bin_grid(image, r_array, pixel_sizes, statistic='mean', mask=None,
     bins: array, optional
         The bins to use in the integration, if none given the function will
         give its best assessment based on the pixel_size and r_array
+
     Returns
     -------
     bin_centers : array
         The center of each bin in R
     int_stat : array
         Radial integrated statistic of the image.
+
     See Also
     --------
     circular_average : circularly average an image, assuming linear radial
         spacing (less general)
+
     """
     if mask is None:
         mask = np.ones(image.shape, dtype=int).astype(bool)

--- a/skbeam/core/utils.py
+++ b/skbeam/core/utils.py
@@ -1357,9 +1357,6 @@ def bin_grid(image, r_array, pixel_sizes, statistic='mean', mask=None,
                 col1 = width - 1
 
 
-            #print("r0, c0: ",row0,col0)
-            #print("r1, c1: ", row1, col1)
-
             r, c = np.linspace(row0, row1, num), np.linspace(col0, col1, num) #sample 1000 points between endpoints
             im_slice = t[r.astype(np.int), c.astype(np.int)]  #extract data from these indexed locations
             im_slice = im_slice[::q]
@@ -1383,10 +1380,6 @@ def bin_grid(image, r_array, pixel_sizes, statistic='mean', mask=None,
                 axes[0].plot([col0, col1], [row0, row1], 'ro-')
                 axes[0].axis('image')
 
-                #if(center_x != None and center_y != None):
-                   # axes[0].scatter(center_x, center_y, s= 50, c='red')
-
-                #if mute_graph != True:
                 axes[1].plot(radius, im_slice)
                 plt.xlabel("Radius", fontsize = 15)
                 plt.ylabel("Intensity", fontsize = 15)
@@ -1399,7 +1392,7 @@ def bin_grid(image, r_array, pixel_sizes, statistic='mean', mask=None,
                 break
             curr = curr + increment
 
-        if(mute_graph==False and center_x != None and center_y != None):
+        if(mute_graph == False and center_x != None and center_y != None):
                     axes[0].scatter(center_x, center_y, s= 50, c='red')
         plt.show()
         return data

--- a/skbeam/core/utils.py
+++ b/skbeam/core/utils.py
@@ -1301,9 +1301,11 @@ def bin_grid(image, r_array, pixel_sizes, statistic='mean', mask=None,
         Returns
         -------
         data : list
-            A list of tuples that contains data from each cut. Each tuple contains the angle of the cut taken, an array of the intensity values sampled along the line cut
-            and an array of the corresponding radii relative to center at each point sampled along the
-            line cut.
+            A list of tuples that contains data from each cut. Each tuple
+            contains the angle of the cut taken, an array of the intensity
+            values sampled along the line cut and an array of the
+            corresponding radii relative to center at each point sampled
+            along the line cut.
 
         """
         height = image.shape[0]

--- a/skbeam/core/utils.py
+++ b/skbeam/core/utils.py
@@ -52,8 +52,6 @@ from itertools import tee
 import logging
 import scipy.stats as sts
 
-from matplotlib import pyplot as plt
-
 logger = logging.getLogger(__name__)
 
 md_value = namedtuple("md_value", ['value', 'units'])
@@ -70,7 +68,6 @@ class NotInstalledError(ImportError):
     '''
     Custom exception that should be subclassed to handle
     specific missing libraries
-
     '''
     pass
 
@@ -78,11 +75,9 @@ class NotInstalledError(ImportError):
 class MD_dict(MutableMapping):
     """
     A class to make dealing with the meta-data scheme for DataExchange easier
-
     Examples
     --------
     Getting and setting data by path is possible
-
     >>> tt = MD_dict()
     >>> tt['name'] = 'test'
     >>> tt['nested.a'] = 2
@@ -219,15 +214,12 @@ class verbosedict(dict):
 
 class RCParamDict(MutableMapping):
     """A class to make dealing with storing default values easier.
-
     RC params is a hold- over from the UNIX days where configuration
     files are 'rc' files.  See
     http://en.wikipedia.org/wiki/Configuration_file
-
     Examples
     --------
     Getting and setting data by path is possible
-
     >>> tt = RCParamDict()
     >>> tt['name'] = 'test'
     >>> tt['nested.a'] = 2
@@ -447,30 +439,25 @@ def subtract_reference_images(imgs, is_reference):
     background/dark current/reference images.  The nearest reference
     image in the reverse temporal direction is subtracted from each
     measured image.
-
     Parameters
     ----------
     imgs : numpy.ndarray
         Array of 2-D images
-
     is_reference : 1-D boolean array
         true  : image is reference image
         false : image is measured image
-
     Returns
     -------
     img_corr : numpy.ndarray
         len(img_corr) == len(img_arr) - len(is_reference_img == true)
         img_corr is the array of measured images minus the reference
         images.
-
     Raises
     ------
     ValueError
         Possible causes:
             is_reference contains no true values
             Raised when the first image in the array is not a reference image.
-
     """
     # an array of 1, 0, 1,.. should work too
     if not is_reference[0]:
@@ -498,7 +485,6 @@ def img_to_relative_xyi(img, cx, cy, pixel_size_x=None, pixel_size_y=None):
     Convert the 2D image to a list of x y I coordinates where
     x == x_img - detector_center[0] and
     y == y_img - detector_center[1]
-
     Parameters
     ----------
     img: `ndarray`
@@ -513,7 +499,6 @@ def img_to_relative_xyi(img, cx, cy, pixel_size_x=None, pixel_size_y=None):
         Pixel size in y
     **kwargs: dict
         Bucket for extra parameters in an unpacked dictionary
-
     Returns
     -------
     x : `ndarray`
@@ -552,7 +537,6 @@ def img_to_relative_xyi(img, cx, cy, pixel_size_x=None, pixel_size_y=None):
 def bin_1D(x, y, nx=None, min_x=None, max_x=None):
     """
     Bin the values in y based on their x-coordinates
-
     Parameters
     ----------
     x : array
@@ -565,15 +549,12 @@ def bin_1D(x, y, nx=None, min_x=None, max_x=None):
         Left edge of first bin defaults to minimum value of x
     max_x : float, optional
         Right edge of last bin defaults to maximum value of x
-
     Returns
     -------
     edges : array
         edges of bins, length nx + 1
-
     val : array
         sum of values in each bin, length nx
-
     count : array
         The number of counts in each bin, length nx
     """
@@ -597,7 +578,6 @@ def bin_1D(x, y, nx=None, min_x=None, max_x=None):
 
 def radial_grid(center, shape, pixel_size=None):
     """Convert a cartesian grid (x,y) to the radius relative to some center
-
     Parameters
     ----------
     center : tuple
@@ -611,7 +591,6 @@ def radial_grid(center, shape, pixel_size=None):
         The physical size of the pixels.
         len(pixel_size) should be the same as len(shape)
         defaults to (1,1)
-
     Returns
     -------
     r : array
@@ -630,24 +609,19 @@ def radial_grid(center, shape, pixel_size=None):
 def angle_grid(center, shape, pixel_size=None):
     """
     Make a grid of angular positions.
-
     Read note for our conventions here -- there be dragons!
-
     Parameters
     ----------
     center : tuple
         point in image where r=0; may be a float giving subpixel precision.
         Order is (rr, cc).
-
     shape: tuple
         Image shape which is used to determine the maximum extent of output
         pixel coordinates. Order is (rr, cc).
-
     Returns
     -------
     agrid : array
         angular position (in radians) of each array element in range [-pi, pi]
-
     Note
     ----
     :math:`\\theta`, the counter-clockwise angle from the positive x axis,
@@ -671,15 +645,12 @@ def radius_to_twotheta(dist_sample, radius):
     """
     Converts radius from the calibrated center to scattering angle
     (2:math:`2\\theta`) with known detector to sample distance.
-
     Parameters
     ----------
     dist_sample : float
         distance from the sample to the detector (mm)
-
     radius : array
         The L2 norm of the distance of each pixel from the calibrated center.
-
     Returns
     -------
     two_theta : array
@@ -692,30 +663,23 @@ def wedge_integration(src_data, center, theta_start,
                       delta_theta, r_inner, delta_r):
     """
     Implementation of caking.
-
     Parameters
     ----------
     scr_data : ndarray
         The source-data to be integrated
-
     center : ndarray
         The center of the ring in pixels
-
     theta_start : float
         The angle of the start of the wedge from the
         image y-axis in degrees
-
     delta_theta : float
         The angular width of the wedge in degrees.  Positive
         angles go clockwise, negative go counter-clockwise.
-
     r_inner : float
         The inner radius in pixel units, Must be non-negative
-
     delta_r : float
         The length of the wedge in the radial direction
         in pixel units. Must be non-negative
-
     Returns
     -------
     float
@@ -729,23 +693,18 @@ def bin_edges(range_min=None, range_max=None, nbins=None, step=None):
     Generate bin edges.  The last value in the returned array is
     the right edge of the last bin, the rest of the values are the
     left edges of each bin.
-
     If `range_max` is specified all bin edges will be less than or
     equal to it's value.
-
     If `range_min` is specified all bin edges will be greater than
     or equal to it's value
-
     If `nbins` is specified then there will be than number of bins and
     the returned array will have length `nbins + 1` (as the right most
     edge is included)
-
     If `step` is specified then bin width is approximately `step` (It is
     not exact due to the nature of floats). The arrays generated by
     `np.cumsum(np.ones(nbins) * step)` and `np.arange(nbins) * step` are
     not identical.  This function uses the second method in all cases
     where `step` is specified.
-
     .. warning :: If the set :code:`(range_min, range_max, step)` is
         given there is no guarantee that :code:`range_max - range_min`
         is an integer multiple of :code:`step`.  In this case the left
@@ -755,22 +714,17 @@ def bin_edges(range_min=None, range_max=None, nbins=None, step=None):
         :code:`step` (this is the same behavior as the built-in
         :code:`range()`).  It is not recommended to specify bins in this
         manner.
-
     Parameters
     ----------
     range_min : float, optional
         The minimum value that may be included as a bin edge
-
     range_max : float, optional
         The maximum value that may be included as a bin edge
-
     nbins : int, optional
         The number of bins, if specified the length of the returned
         value will be nbins + 1
-
     step : float, optional
         The step between the bins
-
     Returns
     -------
     edges : np.array
@@ -831,11 +785,9 @@ def grid3d(q, img_stack,
            ymax=None, zmin=None, zmax=None,
            binary_mask=None):
     """Grid irregularly spaced data points onto a regular grid via histogramming
-
     This function will process the set of reciprocal space values (q), the
     image stack (img_stack) and grid the image data based on the bounds
     provided, using defaults if none are provided.
-
     Parameters
     ----------
     q : ndarray
@@ -867,7 +819,6 @@ def grid3d(q, img_stack,
         Binary mask can be two different shapes.
         - 1: 2-D with binary_mask.shape == np.asarray(img_stack[0]).shape
         - 2: 3-D with binary_mask.shape == np.asarray(img_stack).shape
-
     Returns
     -------
     mean : ndarray
@@ -881,7 +832,6 @@ def grid3d(q, img_stack,
     bounds : list
         tuple of (min, max, step) for x, y, z in order: [x_bounds,
         y_bounds, z_bounds]
-
     """
     try:
         from ..ext import ctrans
@@ -977,13 +927,11 @@ def bin_edges_to_centers(input_edges):
     """
     Helper function for turning a array of bin edges into
     an array of bin centers
-
     Parameters
     ----------
     input_edges : array-like
         N + 1 values which are the left edges of N bins
         and the right edge of the last bin
-
     Returns
     -------
     centers : ndarray
@@ -1005,24 +953,17 @@ def q_to_d(q):
     """
     Helper function to convert :math:`d` to :math:`q`.  The point
     of this function is to prevent fat-fingered typos.
-
     By definition the relationship is:
-
     .. math::
-
         q = \\frac{2 \pi}{d}
-
-
     Parameters
     ----------
     q : array
         An array of q values
-
     Returns
     -------
     d : array
        An array of d (plane) spacing in the inverse of the units of ``q``
-
     """
     return (2 * np.pi) / np.asarray(q)
 
@@ -1031,24 +972,17 @@ def d_to_q(d):
     """
     Helper function to convert :math:`d` to :math:`q`.
     The point of this function is to prevent fat-fingered typos.
-
     By definition the relationship is:
-
     .. math::
-
         d = \\frac{2 \pi}{q}
-
     Parameters
     ----------
     d : array
        An array of d (plane) spacing
-
     Returns
     -------
     q : array
         An array of q values in the inverse of the units of ``d``
-
-
     """
     return (2 * np.pi) / np.asarray(d)
 
@@ -1056,27 +990,18 @@ def d_to_q(d):
 def q_to_twotheta(q, wavelength):
     r"""
     Helper function to convert q to two-theta.
-
     By definition the relationship is:
-
     .. math::
-
         \sin\left(\frac{2\theta}{2}\right) = \frac{\lambda q}{4 \pi}
-
     thus
-
     .. math::
-
         2\theta_n = 2 \arcsin\left(\frac{\lambda q}{4 \pi}\right)
-
     Parameters
     ----------
     q : array
         An array of :math:`q` values
-
     wavelength : float
         Wavelength of the incoming x-rays
-
     Returns
     -------
     two_theta : array
@@ -1091,29 +1016,18 @@ def q_to_twotheta(q, wavelength):
 def twotheta_to_q(two_theta, wavelength):
     r"""
     Helper function to convert two-theta to q
-
     By definition the relationship is
-
     .. math::
-
         \sin\left(\frac{2\theta}{2}\right) = \frac{\lambda q}{4 \pi}
-
     thus
-
     .. math::
-
         q = \frac{4 \pi \sin\left(\frac{2\theta}{2}\right)}{\lambda}
-
-
-
     Parameters
     ----------
     two_theta : array
         An array of :math:`2\theta` values
-
     wavelength : float
         Wavelength of the incoming x-rays
-
     Returns
     -------
     q : array
@@ -1130,7 +1044,6 @@ def multi_tau_lags(multitau_levels, multitau_channels):
     """
     Standard multiple-tau algorithm for finding the lag times (delay
     times).
-
     Parameters
     ----------
     multitau_levels : int
@@ -1138,7 +1051,6 @@ def multi_tau_lags(multitau_levels, multitau_channels):
     multitau_channels : int
         number of channels or number of buffers in auto-correlators
         normalizations (must be even)
-
     Returns
     -------
     total_channels : int
@@ -1147,14 +1059,11 @@ def multi_tau_lags(multitau_levels, multitau_channels):
         delay or lag steps for the multiple tau analysis
     dict_lags : dict
         dictionary of delays for each multitau_levels
-
     Notes
     -----
     The multi-tau correlation scheme was used for finding the lag times
     (delay times).
-
     References: text [1]_
-
     .. [1] K. Schätzela, M. Drewela and  S. Stimaca, "Photon correlation
        measurements at large lag times: Improving statistical accuracy,"
        J. Mod. Opt., vol 35, p 711–718, 1988.
@@ -1192,30 +1101,23 @@ def geometric_series(common_ratio, number_of_images, first_term=1):
     ex: number_of_images = 100, first_term =1
     common_ratio = 2, geometric_series =  1, 2, 4, 8, 16, 32, 64
     common_ratio = 3, geometric_series =  1, 3, 9, 27, 81
-
     Parameters
     ----------
     common_ratio : float
         common ratio of the series
-
     number_of_images : int
         number of images
-
     first_term : float, optional
         first term in the series
-
     Return
     ------
     geometric_series : list
         time series
-
     Notes
     -----
     .. math::
         a + ar + ar^2 + ar^3 + ar^4 + ...
-
     a - first term in the series
-
     r - is the common ratio
     """
 
@@ -1230,7 +1132,6 @@ def bin_grid(image, r_array, pixel_sizes, statistic='mean', mask=None,
              bins=None):
     """
     Bin and integrate an image, given the radial array of pixels
-
     Parameters
     ----------
     image: np.array
@@ -1246,19 +1147,16 @@ def bin_grid(image, r_array, pixel_sizes, statistic='mean', mask=None,
     bins: array, optional
         The bins to use in the integration, if none given the function will
         give its best assessment based on the pixel_size and r_array
-
     Returns
     -------
     bin_centers : array
         The center of each bin in R
     int_stat : array
         Radial integrated statistic of the image.
-
     See Also
     --------
     circular_average : circularly average an image, assuming linear radial
         spacing (less general)
-
     """
     if mask is None:
         mask = np.ones(image.shape, dtype=int).astype(bool)
@@ -1275,124 +1173,3 @@ def bin_grid(image, r_array, pixel_sizes, statistic='mean', mask=None,
     bin_centers = bin_edges_to_centers(bin_edge)
 
     return bin_centers, int_stat
-
-    def angular_cut(image, angle, increment = None, stop = None,
-                    mute_graph = False, v_min = None, v_max = None, num =1000):
-        """
-        Take angled cut or multiple incremented cuts of a image data.
-
-        Parameters
-        ----------
-        image : ndarray
-            Image data
-        angle : float
-            Desired angle for cut to be taken counter-clockwise from the horizontal axis
-        increment : float
-            The angular increment between line cuts if more than one is desired
-        stop : float
-            Maximum value for a set of incremented cuts
-        mute_graph : boolean
-            Mute the image and intensity plot
-        v_min, v_max : float
-            Set limits for matplotlib color map values
-        num : float
-            Number of intensity data points sampled between endpoints of angular cut
-
-        Returns
-        -------
-        data : list
-            A list of tuples that contains data from each cut. Each tuple
-            contains the angle of the cut taken, an array of the intensity
-            values sampled along the line cut and an array of the
-            corresponding radii relative to center at each point sampled
-            along the line cut.
-
-        """
-        height = image.shape[0]
-        width = image.shape[1]
-        center_x = (width - 1)/2.0
-        center_y = (height - 1)/2.0
-        if mute_graph == False:
-            fig, axes = plt.subplots(nrows=2, figsize = (10,10))
-            axes[0].scatter(center_x, center_y, s= 50, c='red')
-
-        curr = angle
-        data = []
-
-        t = image
-
-        while True:
-            q = -1
-
-            theta = curr*(np.pi)/180
-
-            threshold = np.arctan(height/width)
-
-            row0 = 0 #two endpoints of line at angle theta
-            col0 = 0
-
-            row1 = 0
-            col1 = 0
-            if theta >= np.pi:
-                theta = theta - np.pi
-            if theta > threshold or theta <= np.pi - threshold:
-                row0 = 0
-                row1 = height - 1
-                col0 = int((width/2)+(height/2)*np.tan((np.pi/2) - theta))
-                col1 = int((width/2)-(height/2)*np.tan((np.pi/2) - theta))
-                if col1 >= height:
-                    col1 -= 1
-            if theta <= threshold:
-                row0 = int((height/2) - (width/2)*np.tan(theta))
-                row1 = int((height/2) + (width/2)*np.tan(theta))
-                if row1 >= height:
-                    row1 -= 1
-                col0 = width - 1
-                col1 = 0
-
-            if theta > np.pi - threshold:
-                row0 = int((height/2) + (width/2)*np.tan(theta))
-                row1 = int((height/2) - (width/2)*np.tan(theta))
-                col0 = 0
-                col1 = width - 1
-
-
-            r, c = np.linspace(row0, row1, num), np.linspace(col0, col1, num) #sample 1000 points between endpoints
-            im_slice = t[r.astype(np.int), c.astype(np.int)]  #extract data from these indexed locations
-            im_slice = im_slice[::q]
-            radius = []
-            grid = radial_grid(center = (center_y, center_x), shape = (height, width))
-
-            for i in range(len(r)):
-                p1 = int(r[i])
-                p2 = int(c[i])
-                rad = grid[p1][p2]
-                radius.append(rad)
-
-            radius = radius[::q]
-
-            if mute_graph == False:
-                if(v_min != None and v_max != None):
-                    axes[0].imshow(t, vmin= v_min,vmax =  v_max)
-                else:
-                    axes[0].imshow(t)
-
-                axes[0].plot([col0, col1], [row0, row1], 'ro-')
-                axes[0].axis('image')
-
-                axes[1].plot(radius, im_slice)
-                plt.xlabel("Radius", fontsize = 15)
-                plt.ylabel("Intensity", fontsize = 15)
-
-            data.append((curr, im_slice, radius))
-
-            if increment == None:
-                break
-            if curr + increment > stop:
-                break
-            curr = curr + increment
-
-        if(mute_graph == False and center_x != None and center_y != None):
-                    axes[0].scatter(center_x, center_y, s= 50, c='red')
-        plt.show()
-        return data

--- a/skbeam/core/utils.py
+++ b/skbeam/core/utils.py
@@ -52,6 +52,8 @@ from itertools import tee
 import logging
 import scipy.stats as sts
 
+from matplotlib import pyplot as plt
+
 logger = logging.getLogger(__name__)
 
 md_value = namedtuple("md_value", ['value', 'units'])
@@ -1273,3 +1275,129 @@ def bin_grid(image, r_array, pixel_sizes, statistic='mean', mask=None,
     bin_centers = bin_edges_to_centers(bin_edge)
 
     return bin_centers, int_stat
+
+    def angular_cut(image, angle, increment = None, stop = None,
+                    mute_graph = False, v_min = None, v_max = None, num =1000):
+        """
+        Take angled cut or multiple incremented cuts of a image data.
+
+        Parameters
+        ----------
+        image : ndarray
+            Image data
+        angle : float
+            Desired angle for cut to be taken counter-clockwise from the horizontal axis
+        increment : float
+            The angular increment between line cuts if more than one is desired
+        stop : float
+            Maximum value for a set of incremented cuts
+        mute_graph : boolean
+            Mute the image and intensity plot
+        v_min, v_max : float
+            Set limits for matplotlib color map values
+        num : float
+            Number of intensity data points sampled between endpoints of angular cut
+
+        Returns
+        -------
+        data : tuple
+            For each line cut made, returns the angle of the cut, an array of the intensity values sampled
+            and an array of the corresponding radii relative to center at each data point along the
+            line cut.
+
+        """
+        height = image.shape[0]
+        width = image.shape[1]
+        center_x = (width - 1)/2.0
+        center_y = (height - 1)/2.0
+        if mute_graph == False:
+            fig, axes = plt.subplots(nrows=2, figsize = (10,10))
+            axes[0].scatter(center_x, center_y, s= 50, c='red')
+            
+        curr = angle
+        data = []
+
+        t = image
+
+        while True:
+            q = -1
+
+            theta = curr*(np.pi)/180
+
+            threshold = np.arctan(height/width)
+
+            row0 = 0 #two endpoints of line at angle theta
+            col0 = 0
+
+            row1 = 0
+            col1 = 0
+            if theta >= np.pi:
+                theta = theta - np.pi
+            if theta > threshold or theta <= np.pi - threshold:
+                row0 = 0
+                row1 = height - 1
+                col0 = int((width/2)+(height/2)*np.tan((np.pi/2) - theta))
+                col1 = int((width/2)-(height/2)*np.tan((np.pi/2) - theta))
+                if col1 >= height:
+                    col1 -= 1
+            if theta <= threshold:
+                row0 = int((height/2) - (width/2)*np.tan(theta))
+                row1 = int((height/2) + (width/2)*np.tan(theta))
+                if row1 >= height:
+                    row1 -= 1
+                col0 = width - 1
+                col1 = 0
+
+            if theta > np.pi - threshold:
+                row0 = int((height/2) + (width/2)*np.tan(theta))
+                row1 = int((height/2) - (width/2)*np.tan(theta))
+                col0 = 0
+                col1 = width - 1
+
+
+            #print("r0, c0: ",row0,col0)
+            #print("r1, c1: ", row1, col1)
+
+            r, c = np.linspace(row0, row1, num), np.linspace(col0, col1, num) #sample 1000 points between endpoints
+            im_slice = t[r.astype(np.int), c.astype(np.int)]  #extract data from these indexed locations
+            im_slice = im_slice[::q]
+            radius = []
+            grid = radial_grid(center = (center_y, center_x), shape = (height, width))
+
+            for i in range(len(r)):
+                p1 = int(r[i])
+                p2 = int(c[i])
+                rad = grid[p1][p2]
+                radius.append(rad)
+
+            radius = radius[::q]
+
+            if mute_graph == False:
+                if(v_min != None and v_max != None):
+                    axes[0].imshow(t, vmin= v_min,vmax =  v_max)
+                else:
+                    axes[0].imshow(t)
+
+                axes[0].plot([col0, col1], [row0, row1], 'ro-')
+                axes[0].axis('image')
+
+                #if(center_x != None and center_y != None):
+                   # axes[0].scatter(center_x, center_y, s= 50, c='red')
+
+                #if mute_graph != True:
+                axes[1].plot(radius, im_slice)
+                plt.xlabel("Radius", fontsize = 15)
+                plt.ylabel("Intensity", fontsize = 15)
+
+            data.append((curr, im_slice, radius))
+
+            if increment == None:
+                break
+            if curr + increment > stop:
+                break
+            curr = curr + increment
+
+        if(mute_graph==False and center_x != None and center_y != None):
+                    axes[0].scatter(center_x, center_y, s= 50, c='red')
+        plt.show()
+        return data


### PR DESCRIPTION
Here's an alternate find center rings function that uses the Hough Transform. It seemed to work better on soft edged images than using auto_find_center_rings(). It employs the circular Hough Transform to find candidate rings and then finds the center coordinate as the average of the circles' centers. 

My function is based on a sci_kit image Hough Transform notebook:  https://scikit-image.org/docs/dev/auto_examples/edges/plot_circular_elliptical_hough_transform.html?highlight=hough%20transform

Example notebook for my function:
https://nbviewer.jupyter.org/github/madelinegullen/find_center_rings/blob/master/example_find_center_rings.ipynb