### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@
 ### install with conda
 
 ```
-conda config --add channels scikit-beam
-conda install scikit-beam
+conda install scikit-beam -c nsls2forge
+
 ```
 
 ### install development version with setuptools


### PR DESCRIPTION
The readme suggested installing from conda-forge, which has a very out-of-date buggy version of scikit-beam. This install method was suggested by @mrakitin 

Edited by @mrakitin: closes #549.