### PR TITLE
More stable implementation of 'gaussian_tail' function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ python:
 env:
   - NUMPY=1.16
   - NUMPY=1.17
+  - NUMPY=1.18
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ python:
   - 3.7
 
 env:
-  - NUMPY=1.15
   - NUMPY=1.16
   - NUMPY=1.17
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ lmfit
 numpy>=1.15
 pyfai
 scikit-image
-scipy<=1.3.3
+scipy
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ lmfit
 numpy>=1.15
 pyfai
 scikit-image
-scipy
+scipy<=1.3.3
 six

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -108,11 +108,11 @@ class TestRadialBinnedStatistic(object):
                 )
                 centers = bin_edges_to_centers(edges)
 
-                assert_array_equal(ref, binned)
-                assert_array_equal(edges, radbinstat.bin_edges)
-                assert_array_equal(edges, radbinstat_f.bin_edges)
-                assert_array_equal(centers, radbinstat.bin_centers)
-                assert_array_equal(centers, radbinstat_f.bin_centers)
+                assert_array_almost_equal(ref, binned)
+                assert_array_almost_equal(edges, radbinstat.bin_edges)
+                assert_array_almost_equal(edges, radbinstat_f.bin_edges)
+                assert_array_almost_equal(centers, radbinstat.bin_centers)
+                assert_array_almost_equal(centers, radbinstat_f.bin_centers)
 
         bins = (100, 2)
         myrphikwargs = [{'origin': (0, 0),
@@ -174,11 +174,11 @@ class TestRadialBinnedStatistic(object):
                     bins=bins,
                 )
 
-                assert_array_equal(ref, binned)
-                assert_array_equal(redges, rphibinstat.bin_edges[0])
-                assert_array_equal(redges, rphibinstat_f.bin_edges[0])
-                assert_array_equal(phiedges, rphibinstat.bin_edges[1])
-                assert_array_equal(phiedges, rphibinstat_f.bin_edges[1])
+                assert_array_almost_equal(ref, binned)
+                assert_array_almost_equal(redges, rphibinstat.bin_edges[0])
+                assert_array_almost_equal(redges, rphibinstat_f.bin_edges[0])
+                assert_array_almost_equal(phiedges, rphibinstat.bin_edges[1])
+                assert_array_almost_equal(phiedges, rphibinstat_f.bin_edges[1])
 
         # test exception when BinnedStatistic is given array of incorrect shape
         with assert_raises(ValueError):
@@ -207,10 +207,10 @@ def test_BinnedStatistics1D(stat, stat_f):
     ref, edges, _ = scipy.stats.binned_statistic(x, values,
                                                  statistic=stat, bins=10)
 
-    assert_array_equal(bs(values), ref)
+    assert_array_almost_equal(bs(values), ref)
     assert_array_almost_equal(bs_f(values), ref)
-    assert_array_equal(edges, bs.bin_edges)
-    assert_array_equal(edges, bs_f.bin_edges)
+    assert_array_almost_equal(edges, bs.bin_edges)
+    assert_array_almost_equal(edges, bs_f.bin_edges)
 
     rbinstat = BinnedStatistic1D(x)
     # make sure wrong shape is caught

--- a/skbeam/core/accumulators/tests/test_binned_statistic.py
+++ b/skbeam/core/accumulators/tests/test_binned_statistic.py
@@ -2,7 +2,7 @@ from skbeam.core.accumulators.binned_statistic import (RadialBinnedStatistic,
                                                        RPhiBinnedStatistic,
                                                        BinnedStatistic1D,
                                                        BinnedStatisticDD)
-from numpy.testing import assert_array_equal, assert_array_almost_equal, assert_raises
+from numpy.testing import assert_array_almost_equal, assert_raises
 import numpy as np
 import scipy.stats
 from skbeam.core.utils import bin_edges_to_centers

--- a/skbeam/core/fitting/lineshapes.py
+++ b/skbeam/core/fitting/lineshapes.py
@@ -229,10 +229,10 @@ def gaussian_tail(x, area, center, sigma, gamma):
     dx_neg[dx_neg > 0] = 0
 
     temp_a = np.exp(dx_neg / (gamma * sigma))
-    counts = (area /
-              (2 * gamma * sigma * np.exp(-0.5 / (gamma**2))) * temp_a *
-              scipy.special.erfc((x - center) / (np.sqrt(2) * sigma) +
-                                 (1 / (gamma * np.sqrt(2)))))
+
+    v1 = scipy.special.erfc((x - center) / (np.sqrt(2) * sigma) + (1 / (gamma * np.sqrt(2))))
+    v2 = 2 * gamma * sigma * np.exp(-0.5 / (gamma ** 2))
+    counts = area * temp_a * (v1 / v2)
 
     return counts
 


### PR DESCRIPTION
The changes are made to improve numerical stability of `gaussian_tail` function. The proposed changes are preventing overflow due to division of the peak area by a very small number (in the order of 1e-308) and are fixing crashing behavior of PyXRF that happens while attempting to compute Compton scattering model for certain scans. 

Requirements had to be changed: SciPy<=1.3.3. The following tests were failing for SciPy 1.4:
- `test_RadialBinnedStatistic`
- `test_RadialBinnedStatistic_rmap`