### PR TITLE
Compatibility with xraylib 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ parts/
 sdist/
 var/
 venv/
+pip-wheel-metadata/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 
 addons:
   apt_packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,10 @@ python:
 env:
   - NUMPY=1.16
   - NUMPY=1.17
-  - NUMPY=1.18
+  - NUMPY=1.18 XRAYLIB=3
+  - NUMPY=1.18 XRAYLIB=4
+
+
 
 before_install:
   - |
@@ -53,7 +56,7 @@ install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - conda create -n testenv python=$TRAVIS_PYTHON_VERSION numpy=$NUMPY
   - conda activate testenv
-  - conda install xraylib  # this is the only package not available on PyPI
+  - conda install xraylib=XRAYLIB  # this is the only package not available on PyPI
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
   # # need to build_ext -i for the tests so that the .so is local to the source

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - conda create -n testenv python=$TRAVIS_PYTHON_VERSION numpy=$NUMPY
   - conda activate testenv
-  - conda install xraylib=XRAYLIB  # this is the only package not available on PyPI
+  - conda install xraylib=$XRAYLIB  # this is the only package not available on PyPI
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
   # # need to build_ext -i for the tests so that the .so is local to the source

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,28 +10,28 @@ env:
     - GH_REF: github.com/scikit-beam/scikit-beam.git
     - secure: "KzntGlmLDUZlAB8ZiSRBtONJypv4atrnFxl+THCW8kg6YbiODcCxG9cez7mfmh63wpJ54+zeGvgGljeVvjb7bjB2p+4hZy+mLoP9xoE1w5qF4XaQ5YTOYaSQqCeWa5cEIi+854gFX7gOfW5qL+EJf7h3HtmndI15zaU5gOPjSDU="
 
-matrix:
+jobs:
   include:
+    - python: 3.6
+      env: NUMPY=1.16
+    - python: 3.6
+      env: NUMPY=1.17
+    - python: 3.6
+      env: NUMPY=1.18
     - python: 3.7
-      env: BUILD_DOCS=true SUBMIT_CODECOV=true NUMPY=1.17
+      env: NUMPY=1.16
+    - python: 3.7
+      env: NUMPY=1.17
+    - python: 3.7
+      env: NUMPY=1.18 XRAYLIB=3
+    - python: 3.7
+      env: BUILD_DOCS=true NUMPY=1.18 XRAYLIB=4 SUBMIT_CODECOV=true
     - os: osx
       language: generic
       env: TRAVIS_PYTHON_VERSION=3.6 NUMPY=1.17
     - os: osx
       language: generic
       env: TRAVIS_PYTHON_VERSION=3.7 NUMPY=1.17
-
-python:
-  - 3.6
-  - 3.7
-
-env:
-  - NUMPY=1.16
-  - NUMPY=1.17
-  - NUMPY=1.18 XRAYLIB=3
-  - NUMPY=1.18 XRAYLIB=4
-
-
 
 before_install:
   - |

--- a/skbeam/core/constants/xrf.py
+++ b/skbeam/core/constants/xrf.py
@@ -305,9 +305,9 @@ class XrayLibWrap_Energy(XrayLibWrap):
             #   This is extensively used in scikit-beam/pyxrf to determine if the lines exist.
             #   Starting from v4.0, xraylib is raising 'ValueError' exception instead. We are
             #   imitating behavior of the old xraylib by catching the exception and returning 0.
-            val =  self._func(self._element,
-                              self._map[key.lower()],
-                              self._incident_energy)
+            val = self._func(self._element,
+                             self._map[key.lower()],
+                             self._incident_energy)
         except ValueError:
             val = 0
 

--- a/skbeam/core/constants/xrf.py
+++ b/skbeam/core/constants/xrf.py
@@ -205,8 +205,16 @@ class XrayLibWrap(Mapping):
             Define which physics quantity to calculate.
         """
 
-        return self._func(self._element,
-                          self._map[key.lower()])
+        try:
+            # xraylib functions for xraylib < 4.0 used to return 0 in case of non-existent lines
+            #   This is extensively used in scikit-beam/pyxrf to determine if the lines exist.
+            #   Starting from v4.0, xraylib is raising 'ValueError' exception instead. We are
+            #   imitating behavior of the old xraylib by catching the exception and returning 0.
+            val = self._func(self._element,
+                             self._map[key.lower()])
+        except ValueError:
+            val = 0
+        return val
 
     def __iter__(self):
         return iter(self._keys)
@@ -292,9 +300,18 @@ class XrayLibWrap_Energy(XrayLibWrap):
         key : str
             defines which physics quantity to calculate
         """
-        return self._func(self._element,
-                          self._map[key.lower()],
-                          self._incident_energy)
+        try:
+            # xraylib functions for xraylib < 4.0 used to return 0 in case of non-existent lines
+            #   This is extensively used in scikit-beam/pyxrf to determine if the lines exist.
+            #   Starting from v4.0, xraylib is raising 'ValueError' exception instead. We are
+            #   imitating behavior of the old xraylib by catching the exception and returning 0.
+            val =  self._func(self._element,
+                              self._map[key.lower()],
+                              self._incident_energy)
+        except ValueError:
+            val = 0
+
+        return val
 
 
 # redefine the doc_title for xrf elements


### PR DESCRIPTION
Starting from xraylib v4.0, the functions are raising exception `ValueError` when called with non-existent emission line/element combination. Previous versions printed optional error message and returned 0. In this PR, the respective functions are changed to catch `ValueError` and return 0.