### PR TITLE
FIX: disable deprecation message when using xraylib v4.0.0 or higher

### DIFF
--- a/skbeam/core/constants/xrf.py
+++ b/skbeam/core/constants/xrf.py
@@ -40,6 +40,7 @@ from __future__ import absolute_import, division, print_function
 from collections.abc import Mapping
 import logging
 
+from distutils.version import LooseVersion
 import numpy as np
 import six
 
@@ -83,7 +84,8 @@ if xraylib is None:
     pass
 else:
     xraylib.XRayInit()
-    xraylib.SetErrorMessages(0)
+    if LooseVersion(xraylib.__version__) < LooseVersion("4.0.0"):
+        xraylib.SetErrorMessages(0)
 
     line_list = [xraylib.KA1_LINE, xraylib.KA2_LINE, xraylib.KA3_LINE,
                  xraylib.KB1_LINE, xraylib.KB2_LINE, xraylib.KB3_LINE, xraylib.KB4_LINE, xraylib.KB5_LINE,


### PR DESCRIPTION
This PR contains small change that disables very annoying deprecation message displayed when the function `SetErrorMessages(0)` is called to disable error messages with `xraylib` v4.0.0 or higher. Starting with v4.0.0, xraylib is raising exceptions instead of printing error messages and the function `SetErrorMessages` does absolutely nothing and shouldn't be called. On the other hand, if an older version of xraylib is installed, the function should be used to disable unnecessary error messages.
The changes include checking for the version of xraylib and bypass calling of `SetErrorMessages` if the version is higher than v4.0.0.

