### PR TITLE
Adding error bars to one_time_from_two_times 

### DIFF
--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -934,7 +934,7 @@ def one_time_from_two_time(two_time_corr, calc_errors = False):
     one_time_corr : array
         matrix of one time correlation
         shape (number of labels(ROI's), number of frames)
-    err_one_time_corr: arry
+    err_one_time_corr: array
         matrix of errors for one time correlation
         shape (number of labels(ROI's), number of frames)
     """

--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -915,7 +915,7 @@ def _validate_and_transform_inputs(num_bufs, num_levels, labels):
     )
 
 
-def one_time_from_two_time(two_time_corr, calc_errors = False):
+def one_time_from_two_time(two_time_corr, calc_errors=False):
     """
     This will provide the one-time correlation data from two-time
     correlation data. An estimator for errors can be calculated 
@@ -945,7 +945,9 @@ def one_time_from_two_time(two_time_corr, calc_errors = False):
         for j in range(g.shape[1]):
             one_time_corr[i, j] = np.nanmean(np.diag(g, k=j))
             if calc_errors:
-                err_one_time_corr[i, j] = np.nanstd(np.diag(g, k=j))/np.sqrt(len(np.diag(g, k=j)))
+                err_one_time_corr[i, j] = np.nanstd(np.diag(g, k=j)) / np.sqrt(
+                    len(np.diag(g, k=j))
+                )
     if calc_errors:
         return one_time_corr, err_one_time_corr
     else:

--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -940,7 +940,8 @@ def one_time_from_two_time(two_time_corr, calc_errors=False):
     """
 
     one_time_corr = np.zeros((two_time_corr.shape[0], two_time_corr.shape[2]))
-    err_one_time_corr = np.zeros((two_time_corr.shape[0], two_time_corr.shape[2]))
+    if calc_errors:
+        err_one_time_corr = np.zeros((two_time_corr.shape[0], two_time_corr.shape[2]))
     for i, g in enumerate(two_time_corr):
         for j in range(g.shape[1]):
             diag_array = np.diag(g, k=j)

--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -934,7 +934,7 @@ def one_time_from_two_time(two_time_corr, calc_errors=False):
     one_time_corr : array
         matrix of one time correlation
         shape (number of labels(ROI's), number of frames)
-    err_one_time_corr: array
+    (optional, if calc_errors=True) err_one_time_corr: array
         matrix of errors for one time correlation
         shape (number of labels(ROI's), number of frames)
     """
@@ -943,10 +943,11 @@ def one_time_from_two_time(two_time_corr, calc_errors=False):
     err_one_time_corr = np.zeros((two_time_corr.shape[0], two_time_corr.shape[2]))
     for i, g in enumerate(two_time_corr):
         for j in range(g.shape[1]):
-            one_time_corr[i, j] = np.nanmean(np.diag(g, k=j))
+            diag_array = np.diag(g, k=j)
+            one_time_corr[i, j] = np.nanmean(diag_array)
             if calc_errors:
-                err_one_time_corr[i, j] = np.nanstd(np.diag(g, k=j)) / np.sqrt(
-                    len(np.diag(g, k=j))
+                err_one_time_corr[i, j] = np.nanstd(diag_array) / np.sqrt(
+                    len(diag_array)
                 )
     if calc_errors:
         return one_time_corr, err_one_time_corr

--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -918,7 +918,7 @@ def _validate_and_transform_inputs(num_bufs, num_levels, labels):
 def one_time_from_two_time(two_time_corr, calc_errors=False):
     """
     This will provide the one-time correlation data from two-time
-    correlation data. An estimator for errors can be calculated 
+    correlation data. An estimator for errors can be calculated
     according to the central limit theorem.
 
     Parameters

--- a/skbeam/core/correlation.py
+++ b/skbeam/core/correlation.py
@@ -915,29 +915,41 @@ def _validate_and_transform_inputs(num_bufs, num_levels, labels):
     )
 
 
-def one_time_from_two_time(two_time_corr):
+def one_time_from_two_time(two_time_corr, calc_errors = False):
     """
     This will provide the one-time correlation data from two-time
-    correlation data.
+    correlation data. An estimator for errors can be calculated 
+    according to the central limit theorem.
 
     Parameters
     ----------
     two_time_corr : array
         matrix of two time correlation
         shape (number of labels(ROI's), number of frames, number of frames)
+    calc_errors: boolean
+        True to calculate error bars, False to not calculate error bars
 
     Returns
     -------
     one_time_corr : array
         matrix of one time correlation
         shape (number of labels(ROI's), number of frames)
+    err_one_time_corr: arry
+        matrix of errors for one time correlation
+        shape (number of labels(ROI's), number of frames)
     """
 
     one_time_corr = np.zeros((two_time_corr.shape[0], two_time_corr.shape[2]))
+    err_one_time_corr = np.zeros((two_time_corr.shape[0], two_time_corr.shape[2]))
     for i, g in enumerate(two_time_corr):
         for j in range(g.shape[1]):
             one_time_corr[i, j] = np.nanmean(np.diag(g, k=j))
-    return one_time_corr
+            if calc_errors:
+                err_one_time_corr[i, j] = np.nanstd(np.diag(g, k=j))/np.sqrt(len(np.diag(g, k=j)))
+    if calc_errors:
+        return one_time_corr, err_one_time_corr
+    else:
+        return one_time_corr
 
 
 class CrossCorrelator:

--- a/skbeam/core/tests/test_correlation.py
+++ b/skbeam/core/tests/test_correlation.py
@@ -68,8 +68,8 @@ def setup():
     rois = np.zeros_like(img_stack[0])
     # make sure that the ROIs can be any integers greater than 1.
     # They do not have to start at 1 and be continuous
-    rois[0: xdim // 10, 0: ydim // 10] = 5
-    rois[xdim // 10: xdim // 5, ydim // 10: ydim // 5] = 3
+    rois[0 : xdim // 10, 0 : ydim // 10] = 5
+    rois[xdim // 10 : xdim // 5, ydim // 10 : ydim // 5] = 3
 
 
 def test_lazy_vs_original():
@@ -121,7 +121,7 @@ def test_lazy_two_time():
     # first half
     gen_second_half = lazy_two_time(
         rois,
-        img_stack[stack_size // 2:],
+        img_stack[stack_size // 2 :],
         stack_size,
         num_bufs=stack_size,
         num_levels=1,
@@ -155,7 +155,7 @@ def test_lazy_one_time():
     # run the correlation on the second half by passing in the state from the
     # first half
     gen_second_half = lazy_one_time(
-        img_stack[stack_size // 2:],
+        img_stack[stack_size // 2 :],
         num_levels,
         num_bufs,
         rois,
@@ -222,8 +222,8 @@ def test_one_time_from_two_time():
     roi = np.zeros_like(imgs[0])
     # make sure that the ROIs can be any integers greater than 1.
     # They do not have to start at 1 and be continuous
-    roi[0: x_dim // 5, 0: y_dim // 10] = 5
-    roi[x_dim // 10: x_dim // 5 + 1, y_dim // 10: y_dim // 5] = 3
+    roi[0 : x_dim // 5, 0 : y_dim // 10] = 5
+    roi[x_dim // 10 : x_dim // 5 + 1, y_dim // 10 : y_dim // 5] = 3
 
     g2, lag_steps, _state = two_time_corr(roi, imgs, stack, num_buf, num_lev)
     g2_t, _ = multi_tau_auto_corr(num_lev, num_buf, roi, imgs)
@@ -254,13 +254,17 @@ def test_one_time_from_two_time():
         g2_t.T[0].mean() / g2_t.T[1].mean(),
         decimal=2,
     )
-    
+
     assert_array_almost_equal(
         error_one_time[0][1:],
-        np.array([np.std(np.diagonal(g2[0], offset=x))/np.sqrt(x) for x in range(1, g2[0].shape[0])]),
-        decimal = 2
+        np.array(
+            [
+                np.std(np.diagonal(g2[0], offset=x)) / np.sqrt(x)
+                for x in range(1, g2[0].shape[0])
+            ]
+        ),
+        decimal=2,
     )
-    
 
 
 @pytest.mark.skipif(

--- a/skbeam/core/tests/test_correlation.py
+++ b/skbeam/core/tests/test_correlation.py
@@ -68,8 +68,8 @@ def setup():
     rois = np.zeros_like(img_stack[0])
     # make sure that the ROIs can be any integers greater than 1.
     # They do not have to start at 1 and be continuous
-    rois[0 : xdim // 10, 0 : ydim // 10] = 5
-    rois[xdim // 10 : xdim // 5, ydim // 10 : ydim // 5] = 3
+    rois[0: xdim // 10, 0: ydim // 10] = 5
+    rois[xdim // 10: xdim // 5, ydim // 10: ydim // 5] = 3
 
 
 def test_lazy_vs_original():
@@ -121,7 +121,7 @@ def test_lazy_two_time():
     # first half
     gen_second_half = lazy_two_time(
         rois,
-        img_stack[stack_size // 2 :],
+        img_stack[stack_size // 2:],
         stack_size,
         num_bufs=stack_size,
         num_levels=1,
@@ -155,7 +155,7 @@ def test_lazy_one_time():
     # run the correlation on the second half by passing in the state from the
     # first half
     gen_second_half = lazy_one_time(
-        img_stack[stack_size // 2 :],
+        img_stack[stack_size // 2:],
         num_levels,
         num_bufs,
         rois,
@@ -222,8 +222,8 @@ def test_one_time_from_two_time():
     roi = np.zeros_like(imgs[0])
     # make sure that the ROIs can be any integers greater than 1.
     # They do not have to start at 1 and be continuous
-    roi[0 : x_dim // 5, 0 : y_dim // 10] = 5
-    roi[x_dim // 10 : x_dim // 5 + 1, y_dim // 10 : y_dim // 5] = 3
+    roi[0: x_dim // 5, 0: y_dim // 10] = 5
+    roi[x_dim // 10: x_dim // 5 + 1, y_dim // 10: y_dim // 5] = 3
 
     g2, lag_steps, _state = two_time_corr(roi, imgs, stack, num_buf, num_lev)
     g2_t, _ = multi_tau_auto_corr(num_lev, num_buf, roi, imgs)

--- a/skbeam/core/tests/test_correlation.py
+++ b/skbeam/core/tests/test_correlation.py
@@ -228,7 +228,7 @@ def test_one_time_from_two_time():
     g2, lag_steps, _state = two_time_corr(roi, imgs, stack, num_buf, num_lev)
     g2_t, _ = multi_tau_auto_corr(num_lev, num_buf, roi, imgs)
 
-    one_time = one_time_from_two_time(g2)
+    one_time, error_one_time = one_time_from_two_time(g2, calc_errors=True)
     assert_array_almost_equal(
         one_time,
         np.array(
@@ -254,6 +254,13 @@ def test_one_time_from_two_time():
         g2_t.T[0].mean() / g2_t.T[1].mean(),
         decimal=2,
     )
+    
+    assert_array_almost_equal(
+        error_one_time[0][1:],
+        np.array([np.std(np.diagonal(g2[0], offset=x))/np.sqrt(x) for x in range(1, g2[0].shape[0])]),
+        decimal = 2
+    )
+    
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Added errors (standard deviation of the mean) for calculating one-time correlation function from two-time correlation function. Made this as optional output, so all the existing code would still work.