### PR TITLE
Modifications to 'get_line_energy' function.

### DIFF
--- a/skbeam/core/fitting/tests/test_xrf_model.py
+++ b/skbeam/core/fitting/tests/test_xrf_model.py
@@ -1,0 +1,30 @@
+import pytest
+import numpy.testing as npt
+
+from skbeam.core.fitting.xrf_model import get_line_energy
+
+
+@pytest.mark.parametrize("elemental_line, energy_expected", [
+    ("Ca_K", 3.6917),
+    ("Ca_Ka", 3.6917),
+    ("Ca_Ka1", 3.6917),
+    ("Ca_Kb", 4.0127),
+    ("Ca_Kb1", 4.0127),
+    ("Ca_Ka3", 3.6003),
+    ("Ca_ka3", 3.6003),
+    ("Ca_kA3", 3.6003),
+    ("Eu_L", 5.8460),
+    ("Eu_La", 5.8460),
+    ("Eu_La1", 5.8460),
+    ("Eu_Lb", 6.4565),
+    ("Eu_Lb1", 6.4565),
+    ("Eu_Lb3", 6.5714),
+    ("U_M", 3.1710),
+    ("U_Ma", 3.1710),
+    ("U_Ma1", 3.1710),
+    ("U_Ma2", 3.1610),
+])
+def test_get_line_energy(elemental_line, energy_expected):
+    energy = get_line_energy(elemental_line)
+    npt.assert_almost_equal(energy, energy_expected,
+                            err_msg="Energy doesn't match expected")

--- a/skbeam/core/fitting/xrf_model.py
+++ b/skbeam/core/fitting/xrf_model.py
@@ -1087,15 +1087,18 @@ class ModelSpectrum(object):
 
 
 def get_line_energy(elemental_line):
-    """Return the energy of the first line in K, L or M series.
+    """Return the energy of the emission line.
 
     Parameters
     ----------
     elemental_line : str
-        For instance, Eu_L is the format for L lines and Pt_M for M lines.
-        And for K lines, user needs to define lines like ka1, kb1,
-        because for K lines, we consider contributions from either ka1
-        or kb1, while for L or M lines, we only consider the primary peak.
+        For instance, Ca_K will return energy of the peak for Ca_ka1 line,
+        Ca_Kb will return energy for Ca_Kb1 line and Ca_Kb2 line will return
+        energy for Ca_Kb2 line. The letters in the element name (e.g. Ca) should
+        be capitalized properly. Letters in the line name may be arbitrarily
+        capitalized, e.g. Ca_kb1 is equivalent to Ca_Kb1 or Ca_KB1.
+        The function is primarily used for finding center of a pileup peak,
+        so typical format for the emission line is Ca_Ka1.
 
     Returns
     -------
@@ -1104,15 +1107,15 @@ def get_line_energy(elemental_line):
     """
     name, line = elemental_line.split('_')
     line = line.lower()
+
+    # Complete the emission line name
+    if len(line) == 1:  # elemental line format 'Ca_K'
+        line += 'a1'
+    elif len(line) == 2:  # elemental line format 'Ca_Ka'
+        line += "1"
+
     e = Element(name)
-    if 'k' in line:
-        e_cen = e.emission_line[line]
-    elif 'l' in line:
-        # only the first line for L
-        e_cen = e.emission_line['la1']
-    else:
-        # only the first line for M
-        e_cen = e.emission_line['ma1']
+    e_cen = e.emission_line[line]
     return e_cen
 
 


### PR DESCRIPTION
The `get_line_energy` function was modified so that now it returns the actual energy of the emission line, not `a1` line. In the existing implementation, `get_line_energy("Ca_Kb1")` would return the energy for "Ca_Ka1" line.

The function was originally developed for estimation of locations of pileup peaks and the assumption that only 'ka1', 'la1' and 'ma1' lines contribute to pileup peaks seems reasonable. But in practice, the full names of emission lines are encoded into the names of pileup peaks (e.g. "V_Ka1-Co-Ka1") and the correct way to compute the accurate line energies using full emission names. If lines are to be restricted only to 'ka1', 'la1' and 'ma1' lines, it should be done at higher level, not at the level of model setup.