### PR TITLE
FIX: changed TL_M to Tl_M

### DIFF
--- a/skbeam/core/fitting/tests/test_xrf_model.py
+++ b/skbeam/core/fitting/tests/test_xrf_model.py
@@ -5,6 +5,7 @@ from xraylib import SymbolToAtomicNumber
 from skbeam.core.fitting.xrf_model import get_line_energy
 from skbeam.core.fitting.xrf_model import K_LINE, L_LINE, M_LINE
 
+
 @pytest.mark.parametrize("elemental_line, energy_expected", [
     ("Ca_K", 3.6917),
     ("Ca_Ka", 3.6917),

--- a/skbeam/core/fitting/tests/test_xrf_model.py
+++ b/skbeam/core/fitting/tests/test_xrf_model.py
@@ -1,8 +1,9 @@
 import pytest
 import numpy.testing as npt
+from xraylib import SymbolToAtomicNumber
 
 from skbeam.core.fitting.xrf_model import get_line_energy
-
+from skbeam.core.fitting.xrf_model import K_LINE, L_LINE, M_LINE
 
 @pytest.mark.parametrize("elemental_line, energy_expected", [
     ("Ca_K", 3.6917),
@@ -28,3 +29,25 @@ def test_get_line_energy(elemental_line, energy_expected):
     energy = get_line_energy(elemental_line)
     npt.assert_almost_equal(energy, energy_expected,
                             err_msg="Energy doesn't match expected")
+
+
+def test_K_L_M_lines():
+    """
+    Test the lists of supported emission lines.
+    """
+    lines = K_LINE + L_LINE + M_LINE
+
+    # Check that all lines are unique
+    assert len(lines) == len(set(lines))
+
+    for line in lines:
+        element, type = line.split('_')
+        # Check emission line name
+        assert type in ('K', 'L', 'M')
+        # Check that the element is supported
+        try:
+            # Returns the number > 0 if successful. May return 0 (xraylib 3) or
+            # raise an exception (xraylib 4) if element is not recognized.
+            assert SymbolToAtomicNumber(element) > 0
+        except ValueError as ex:
+            assert False, f"{ex}: '{element}' (emission line: '{line}')"

--- a/skbeam/core/fitting/xrf_model.py
+++ b/skbeam/core/fitting/xrf_model.py
@@ -81,7 +81,7 @@ L_LINE = ['Ga_L', 'Ge_L', 'As_L', 'Se_L', 'Br_L', 'Kr_L', 'Rb_L', 'Sr_L',
           'Fr_L', 'Ac_L', 'Th_L', 'Pa_L', 'U_L', 'Np_L', 'Pu_L', 'Am_L']
 
 M_LINE = ['Hf_M', 'Ta_M', 'W_M', 'Re_M', 'Os_M', 'Ir_M', 'Pt_M', 'Au_M',
-          'Hg_M', 'TL_M', 'Pb_M', 'Bi_M', 'Sm_M', 'Eu_M', 'Gd_M', 'Tb_M',
+          'Hg_M', 'Tl_M', 'Pb_M', 'Bi_M', 'Sm_M', 'Eu_M', 'Gd_M', 'Tb_M',
           'Dy_M', 'Ho_M', 'Er_M', 'Tm_M', 'Yb_M', 'Lu_M', 'Th_M', 'Pa_M',
           'U_M']
 


### PR DESCRIPTION
Changed representation for the M-line of Tl from `TL_M` to `Tl_M`: `TL_M` is inconsistent with the accepted formatting standard and causes issues in PyXRF.